### PR TITLE
issue fixed

### DIFF
--- a/src/ListBuilder.h
+++ b/src/ListBuilder.h
@@ -3,7 +3,8 @@
 // to Rcpp-devel on Tue, 8 Jul 2014
 //
 
-
+#ifndef LIST_BUILDER_H
+#define LIST_BUILDER_H
 
 #include <Rcpp.h>
 using namespace Rcpp;
@@ -50,10 +51,5 @@ private:
 
 };
 
-// [[Rcpp::export]]
-DataFrame test_builder(SEXP x, SEXP y, SEXP z) {
-  return ListBuilder()
-    .add("foo", x)
-    .add("bar", y)
-    .add("baz", z);
-}
+
+#endif

--- a/src/RcppRamp.cpp
+++ b/src/RcppRamp.cpp
@@ -230,13 +230,9 @@ RcppRamp::getAllScanHeaderInfo ( ) {
 
       ListBuilder header;
       header.add("seqNum", seqNum);
-      header.add("seqNum",                   seqNum);
       header.add("acquisitionNum",           acquisitionNum);
       header.add("msLevel",                  msLevel);
       header.add("polarity",               polarity);
-      header.add("seqNum",                   seqNum);
-      header.add("acquisitionNum",           acquisitionNum);
-      header.add("msLevel",                  msLevel);
       header.add("peaksCount",               peaksCount);
       header.add("totIonCurrent",            totIonCurrent);
       header.add("retentionTime",            retentionTime);


### PR DESCRIPTION
The duplicated items have been removed.

Adding header protection for listbuilder.h. Also the testing function in listbuilder.h has been removed, since it is not a good practice to have a exported function in header files.
