### PR TITLE
Make pwiz default backend (issue #84)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.9.11
+Version: 2.9.12
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou
 Maintainer: Bernd Fischer <b.fischer@dkfz.de>,
 	    Steffen Neumann <sneumann@ipb-halle.de>,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+CHANGES IN VERSION 2.9.12
+-------------------------
+ o Change default I/O backend from Ramp to pwiz.
+
 CHANGES IN VERSION 2.9.11
 -------------------------
  o Restore -fpermissive flag on windows

--- a/R/io.R
+++ b/R/io.R
@@ -1,5 +1,5 @@
 openMSfile <- function(filename,
-                       backend=c("Ramp", "pwiz", "netCDF"),
+                       backend=c("pwiz", "Ramp", "netCDF"),
                        verbose = FALSE) {
     if (!file.exists(filename))
         stop("File ",filename," not found.\n")

--- a/man/openMSfile.Rd
+++ b/man/openMSfile.Rd
@@ -9,7 +9,7 @@
   Create and check mzR objects from netCDF, mzXML, mzData or mzML files.
 }
 \usage{
- openMSfile(filename, backend=c("Ramp", "pwiz", "netCDF"), verbose = FALSE)
+ openMSfile(filename, backend=c("pwiz", "Ramp", "netCDF"), verbose = FALSE)
 
  initializeRamp(object)
 
@@ -23,7 +23,7 @@
   \item{filename}{ Path name of the netCDF, mzData, mzXML or mzML file to
     read/write. }
   \item{backend}{ A \code{character} specifiying with backend API to
-    use. Currently 'Ramp', 'netCDF'  and 'pwiz' are available.}
+    use. Currently 'Ramp', 'netCDF'  and 'pwiz' (default) are available.}
   \item{object}{ An instantiated mzR object. }
   \item{verbose}{ Enable verbose output. }
   \item{...}{ Additional arguments, currently ignored. }


### PR DESCRIPTION
- Change default backend to pwiz.
- Update documentation.
- Passes R CMD check.