### PR TITLE
New header implementation for pwiz backend

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.9.11
+Version: 2.9.12
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou
 Maintainer: Bernd Fischer <b.fischer@dkfz.de>,
 	    Steffen Neumann <sneumann@ipb-halle.de>,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.11.1
+Version: 2.11.2
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou
 Maintainer: Bernd Fischer <b.fischer@dkfz.de>,
 	    Steffen Neumann <sneumann@ipb-halle.de>,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 2.11.2
+-------------------------
+ o New getScanHeaderInfo and getAllScanHeaderInfo implementations for the pwiz
+   backend. Fixes issue #106 and issue #216 in MSnbase.
+
 CHANGES IN VERSION 2.11.1
 -------------------------
  o Change default I/O backend from Ramp to pwiz.

--- a/R/methods-mzRpwiz.R
+++ b/R/methods-mzRpwiz.R
@@ -58,7 +58,6 @@ setMethod("header", c("mzRpwiz", "numeric"),
                   res <- object@backend$getScanHeaderInfo(scans)
                   ## Convert data.frame to list to be conform with old code
                   return(as.list(res))
-              return(object@backend$getScanHeaderInfo(scans))
               } else {
                   return(object@backend$getScanHeaderInfo(scans))
               }

--- a/R/methods-mzRpwiz.R
+++ b/R/methods-mzRpwiz.R
@@ -54,14 +54,21 @@ setMethod("header", c("mzRpwiz", "missing"),
 
 setMethod("header", c("mzRpwiz", "numeric"),
           function(object, scans) {
-            if (length(scans) == 1) {
+              if (length(scans) == 1) {
+                  res <- object@backend$getScanHeaderInfo(scans)
+                  ## Convert data.frame to list to be conform with old code
+                  return(as.list(res))
               return(object@backend$getScanHeaderInfo(scans))
-            } else {
-                return(data.frame(t(sapply(scans,
-                                           function(x)
-                                               unlist(object@backend$getScanHeaderInfo(x))))))
-            }
+              } else {
+                  return(object@backend$getScanHeaderInfo(scans))
+              }
           })
+
+headerFor <- function(object, idx) {
+    if (missing(idx))
+        stop("Required parameter 'idx' is missing.")
+    return(object@backend$getScanHeaderInfoFor(as.integer(idx)))
+}
 
 setMethod("peaks", "mzRpwiz",
           function(object, scans) .peaks(object, scans))

--- a/inst/unitTests/test_pwiz.R
+++ b/inst/unitTests/test_pwiz.R
@@ -44,3 +44,111 @@ test_mzML <- function() {
     fileName(mzml)
     close(mzml)
 }
+
+## Test the new implementation of the getScanHeaderInfo
+test_getScanHeaderInfo <- function() {
+    ## Compare the data returned from the new function with the one returned
+    ## by the Ramp backend.
+    file <- system.file("microtofq", "MM14.mzML", package = "msdata")
+    mzml <- openMSfile(file, backend = "pwiz")
+    ramp <- openMSfile(file, backend = "Ramp")
+    ## Read single scan header.
+    scan_3 <- header(mzml, scans = 3)
+    scan_3_ramp <- header(ramp, scans = 3)
+    ## Ramp does not read polarity
+    scan_3$polarity <- 0
+    checkEquals(scan_3, scan_3_ramp)
+    
+    ## Read all scan header
+    all_scans <- header(mzml)
+    all_scans_ramp <- header(ramp)
+    all_scans$polarity <- 0
+    checkEquals(all_scans, all_scans_ramp)
+    
+    ## passing the index of all scan headers should return the same
+    all_scans_2 <- header(mzml, scans = 1:nrow(all_scans))
+    all_scans_ramp_2 <- header(ramp, scans = 1:nrow(all_scans))
+    all_scans_2$polarity <- 0
+    checkEquals(all_scans, all_scans_2)
+    checkEquals(as.list(all_scans[3, ]), scan_3)
+    checkEquals(all_scans_2, all_scans_ramp_2)
+
+    ## Some selected scans
+    scan_3 <- header(mzml, scans = c(3, 1, 14))
+    scan_3_ramp <- header(ramp, scans = c(3, 1, 14))
+    ## Ramp does not read polarity
+    scan_3$polarity <- 0
+    checkEquals(scan_3, scan_3_ramp)
+
+    close(mzml)
+    close(ramp)
+
+    ## The same for an mzXML file:
+    file <- system.file("threonine", "threonine_i2_e35_pH_tree.mzXML",
+                        package = "msdata")
+    mzml <- openMSfile(file, backend = "pwiz")
+    ramp <- openMSfile(file, backend = "Ramp")
+    ## Read single scan header.
+    scan_3 <- header(mzml, scans = 3)
+    scan_3_ramp <- header(ramp, scans = 3)
+    checkEquals(scan_3, scan_3_ramp)
+    
+    ## Read all scan header
+    all_scans <- header(mzml)
+    all_scans_ramp <- header(ramp)
+    ## Ramp unable to read precursorScanNum from an mzXML file.
+    all_scans$precursorScanNum <- 0
+    checkEquals(all_scans, all_scans_ramp)
+    
+    ## passing the index of all scan headers should return the same
+    all_scans_2 <- header(mzml, scans = 1:nrow(all_scans))
+    all_scans_ramp_2 <- header(ramp, scans = 1:nrow(all_scans))
+    all_scans_2$precursorScanNum <- 0
+    checkEquals(all_scans, all_scans_2)
+    checkEquals(as.list(all_scans[3, ]), scan_3)
+    checkEquals(all_scans_2, all_scans_ramp_2)
+
+    ## Some selected scans
+    scan_3 <- header(mzml, scans = c(3, 1, 14))
+    scan_3_ramp <- header(ramp, scans = c(3, 1, 14))
+    scan_3$precursorScanNum <- 0
+    checkEquals(scan_3, scan_3_ramp)
+
+    close(mzml)
+    close(ramp)
+
+    ## Again for an MSn mzml file.
+    file <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia")
+    mzml <- openMSfile(file, backend = "pwiz")
+    ramp <- openMSfile(file, backend = "Ramp")
+    ## Read single scan header.
+    scan_3 <- header(mzml, scans = 3)
+    scan_3_ramp <- header(ramp, scans = 3)
+    ## Ramp does not read polarity
+    scan_3$polarity <- 0
+    checkEquals(scan_3, scan_3_ramp)
+    
+    ## Read all scan header
+    all_scans <- header(mzml)
+    all_scans_ramp <- header(ramp)
+    all_scans$polarity <- 0
+    checkEquals(all_scans, all_scans_ramp)
+    
+    ## passing the index of all scan headers should return the same
+    all_scans_2 <- header(mzml, scans = 1:nrow(all_scans))
+    all_scans_ramp_2 <- header(ramp, scans = 1:nrow(all_scans))
+    all_scans_2$polarity <- 0
+    checkEquals(all_scans, all_scans_2)
+    checkEquals(as.list(all_scans[3, ]), scan_3)
+    checkEquals(all_scans_2, all_scans_ramp_2)
+
+    ## Some selected scans
+    scan_3 <- header(mzml, scans = c(3, 1, 14))
+    scan_3_ramp <- header(ramp, scans = c(3, 1, 14))
+    ## Ramp does not read polarity
+    scan_3$polarity <- 0
+    checkEquals(scan_3, scan_3_ramp)
+
+    close(mzml)
+    close(ramp)
+}

--- a/src/RcppPwiz.cpp
+++ b/src/RcppPwiz.cpp
@@ -149,163 +149,131 @@ Rcpp::List RcppPwiz::getInstrumentInfo ( )
 }
 
 
-Rcpp::List RcppPwiz::getScanHeaderInfo ( int whichScan  )
+Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan)
 {
     if (msd != NULL)
     {
-        SpectrumListPtr slp = msd->run.spectrumListPtr;
-        if ((whichScan <= 0) || (whichScan > slp->size()))
-        {
-            Rprintf("Index out of bounds [1 ... %d].\n", slp->size());
-            return Rcpp::List::create( );
-        }
-
-        RAMPAdapter * adapter = new  RAMPAdapter(filename);
-        ScanHeaderStruct header;
-        adapter->getScanHeader(whichScan - 1, header);
-
-        Rcpp::List res(21);
-        std::vector<std::string> names;
-        int i = 0;
-
-        names.push_back("seqNum");
-        res[i++] = Rcpp::wrap(header.seqNum);
-        names.push_back("acquisitionNum");
-        res[i++] = Rcpp::wrap(header.acquisitionNum);
-        names.push_back("msLevel");
-        res[i++] = Rcpp::wrap(header.msLevel);
-
-        names.push_back("polarity");
-	SpectrumPtr sp = slp->spectrum(whichScan - 1, true); // Is TRUE neccessary here ? 
-	CVParam param = sp->cvParamChild(MS_scan_polarity);
-	res[i++] = Rcpp::wrap( (param.cvid==MS_negative_scan ? 0 : (param.cvid==MS_positive_scan ? +1 : -1 ) ) );
-	
-	names.push_back("peaksCount");
-        res[i++] = Rcpp::wrap(header.peaksCount);
-        names.push_back("totIonCurrent");
-        res[i++] = Rcpp::wrap(header.totIonCurrent);
-        names.push_back("retentionTime");
-        res[i++] = Rcpp::wrap(header.retentionTime);
-        names.push_back("basePeakMZ");
-        res[i++] = Rcpp::wrap(header.basePeakMZ);
-        names.push_back("basePeakIntensity");
-        res[i++] = Rcpp::wrap(header.basePeakIntensity);
-        names.push_back("collisionEnergy");
-        res[i++] = Rcpp::wrap(header.collisionEnergy);
-        names.push_back("ionisationEnergy");
-        res[i++] = Rcpp::wrap(header.ionisationEnergy);
-        names.push_back("lowMZ");
-        res[i++] = Rcpp::wrap(header.lowMZ);
-        names.push_back("highMZ");
-        res[i++] = Rcpp::wrap(header.highMZ);
-        names.push_back("precursorScanNum");
-        res[i++] = Rcpp::wrap(header.precursorScanNum);
-        names.push_back("precursorMZ");
-        res[i++] = Rcpp::wrap(header.precursorMZ);
-        names.push_back("precursorCharge");
-        res[i++] = Rcpp::wrap(header.precursorCharge);
-        names.push_back("precursorIntensity");
-        res[i++] = Rcpp::wrap(header.precursorIntensity);
-        names.push_back("mergedScan");
-        res[i++] = Rcpp::wrap(header.mergedScan);
-        names.push_back("mergedResultScanNum");
-        res[i++] = Rcpp::wrap(header.mergedResultScanNum);
-        names.push_back("mergedResultStartScanNum");
-        res[i++] = Rcpp::wrap(header.mergedResultStartScanNum);
-        names.push_back("mergedResultEndScanNum");
-        res[i++] = Rcpp::wrap(header.mergedResultEndScanNum);
-
-	// delete adapter issue #64
-	delete adapter;
-	adapter = NULL;
-        res.attr("names") = names;
-        return res;
+      SpectrumListPtr slp = msd->run.spectrumListPtr;
+      int N = slp->size();
+      
+      int N_scans = whichScan.size();
+      
+      ScanHeaderStruct scanHeader;
+      RAMPAdapter * adapter = new  RAMPAdapter(filename);
+      Rcpp::IntegerVector seqNum(N_scans); // number in sequence observed file (1-based)
+      Rcpp::IntegerVector acquisitionNum(N_scans); // scan number as declared in File (may be gaps)
+      Rcpp::IntegerVector msLevel(N_scans);
+      Rcpp::IntegerVector polarity(N_scans);
+      Rcpp::IntegerVector peaksCount(N_scans);
+      Rcpp::NumericVector totIonCurrent(N_scans);
+      Rcpp::NumericVector retentionTime(N_scans);        /* in seconds */
+      Rcpp::NumericVector basePeakMZ(N_scans);
+      Rcpp::NumericVector basePeakIntensity(N_scans);
+      Rcpp::NumericVector collisionEnergy(N_scans);
+      Rcpp::NumericVector ionisationEnergy(N_scans);
+      Rcpp::NumericVector lowMZ(N_scans);
+      Rcpp::NumericVector highMZ(N_scans);
+      Rcpp::IntegerVector precursorScanNum(N_scans); /* only if MS level > 1 */
+      Rcpp::NumericVector precursorMZ(N_scans);  /* only if MS level > 1 */
+      Rcpp::IntegerVector precursorCharge(N_scans);  /* only if MS level > 1 */
+      Rcpp::NumericVector precursorIntensity(N_scans);  /* only if MS level > 1 */
+      //char scanType[SCANTYPE_LENGTH];
+      //char activationMethod[SCANTYPE_LENGTH];
+      //char possibleCharges[SCANTYPE_LENGTH];
+      //int numPossibleCharges;
+      //bool possibleChargesArray[CHARGEARRAY_LENGTH]; /* NOTE: does NOT include "precursorCharge" information; only from "possibleCharges" */
+      Rcpp::IntegerVector mergedScan(N_scans);  /* only if MS level > 1 */
+      Rcpp::IntegerVector mergedResultScanNum(N_scans); /* scan number of the resultant merged scan */
+      Rcpp::IntegerVector mergedResultStartScanNum(N_scans); /* smallest scan number of the scanOrigin for merged scan */
+      Rcpp::IntegerVector mergedResultEndScanNum(N_scans); /* largest scan number of the scanOrigin for merged scan */
+      
+      for (int i = 0; i < N_scans; i++)
+	{
+	  int current_scan = whichScan[i];
+	  adapter->getScanHeader(current_scan - 1, scanHeader, false);
+	  seqNum[i] = scanHeader.seqNum;
+	  acquisitionNum[i] = scanHeader.acquisitionNum;
+	  msLevel[i] = scanHeader.msLevel;
+	  
+	  SpectrumPtr sp = slp->spectrum(current_scan-1, false); // Is TRUE neccessary here ? 
+	  CVParam param = sp->cvParamChild(MS_scan_polarity);
+	  polarity[i] = (param.cvid==MS_negative_scan ? 0 : (param.cvid==MS_positive_scan ? +1 : -1 ) );
+	  
+	  peaksCount[i] = scanHeader.peaksCount;
+	  totIonCurrent[i] = scanHeader.totIonCurrent;
+	  retentionTime[i] = scanHeader.retentionTime;
+	  basePeakMZ[i] = scanHeader.basePeakMZ;
+	  basePeakIntensity[i] = scanHeader.basePeakIntensity;
+	  collisionEnergy[i] = scanHeader.collisionEnergy;
+	  ionisationEnergy[i] = scanHeader.ionisationEnergy;
+	  lowMZ[i] = scanHeader.lowMZ;
+	  highMZ[i] = scanHeader.highMZ;
+	  precursorScanNum[i] = scanHeader.precursorScanNum;
+	  precursorMZ[i] = scanHeader.precursorMZ;
+	  precursorCharge[i] = scanHeader.precursorCharge;
+	  precursorIntensity[i] = scanHeader.precursorIntensity;
+	  mergedScan[i] = scanHeader.mergedScan;
+	  mergedResultScanNum[i] = scanHeader.mergedResultScanNum;
+	  mergedResultStartScanNum[i] = scanHeader.mergedResultStartScanNum;
+	  mergedResultEndScanNum[i] = scanHeader.mergedResultEndScanNum;
+	}
+      // delete adapter issue #64
+      delete adapter;
+      adapter = NULL;
+      
+      Rcpp::List header(21);
+      std::vector<std::string> names;
+      int i = 0;
+      names.push_back("seqNum");
+      header[i++] = Rcpp::wrap(seqNum);
+      names.push_back("acquisitionNum");
+      header[i++] = Rcpp::wrap(acquisitionNum);
+      names.push_back("msLevel");
+      header[i++] = Rcpp::wrap(msLevel);
+      names.push_back("polarity");
+      header[i++] = Rcpp::wrap(polarity);
+      names.push_back("peaksCount");
+      header[i++] = Rcpp::wrap(peaksCount);
+      names.push_back("totIonCurrent");
+      header[i++] = Rcpp::wrap(totIonCurrent);
+      names.push_back("retentionTime");
+      header[i++] = Rcpp::wrap(retentionTime);
+      names.push_back("basePeakMZ");
+      header[i++] = Rcpp::wrap(basePeakMZ);
+      names.push_back("basePeakIntensity");
+      header[i++] = Rcpp::wrap(basePeakIntensity);
+      names.push_back("collisionEnergy");
+      header[i++] = Rcpp::wrap(collisionEnergy);
+      names.push_back("ionisationEnergy");
+      header[i++] = Rcpp::wrap(ionisationEnergy);
+      names.push_back("lowMZ");
+      header[i++] = Rcpp::wrap(lowMZ);
+      names.push_back("highMZ");
+      header[i++] = Rcpp::wrap(highMZ);
+      names.push_back("precursorScanNum");
+      header[i++] = Rcpp::wrap(precursorScanNum);
+      names.push_back("precursorMZ");
+      header[i++] = Rcpp::wrap(precursorMZ);
+      names.push_back("precursorCharge");
+      header[i++] = Rcpp::wrap(precursorCharge);
+      names.push_back("precursorIntensity");
+      header[i++] = Rcpp::wrap(precursorIntensity);
+      names.push_back("mergedScan");
+      header[i++] = Rcpp::wrap(mergedScan);
+      names.push_back("mergedResultScanNum");
+      header[i++] = Rcpp::wrap(mergedResultScanNum);
+      names.push_back("mergedResultStartScanNum");
+      header[i++] = Rcpp::wrap(mergedResultStartScanNum);
+      names.push_back("mergedResultEndScanNum");
+      header[i++] = Rcpp::wrap(mergedResultEndScanNum);
+      
+      header.attr("names") = names;
+      
+      return(header);
     }
-    else
-    {
-        Rprintf("Warning: pwiz not yet initialized.\n ");
-        return Rcpp::List::create( );
-    }
+    Rprintf("Warning: pwiz not yet initialized.\n ");
+    return Rcpp::DataFrame::create( );
 }
-
-// Rcpp::List RcppPwiz::getScanHeaderInfo ( int whichScan  )
-// {
-//     if (msd != NULL)
-//     {
-//         SpectrumListPtr slp = msd->run.spectrumListPtr;
-//         if ((whichScan <= 0) || (whichScan > slp->size()))
-//         {
-//             Rprintf("Index out of bounds [1 ... %d].\n", slp->size());
-//             return Rcpp::List::create( );
-//         }
-
-//         RAMPAdapter * adapter = new  RAMPAdapter(filename);
-//         ScanHeaderStruct header;
-//         adapter->getScanHeader(whichScan - 1, header);
-
-//         Rcpp::List res(21);
-//         std::vector<std::string> names;
-//         int i = 0;
-
-//         names.push_back("seqNum");
-//         res[i++] = Rcpp::wrap(header.seqNum);
-//         names.push_back("acquisitionNum");
-//         res[i++] = Rcpp::wrap(header.acquisitionNum);
-//         names.push_back("msLevel");
-//         res[i++] = Rcpp::wrap(header.msLevel);
-
-//         names.push_back("polarity");
-// 	SpectrumPtr sp = slp->spectrum(whichScan - 1, true); // Is TRUE neccessary here ? 
-// 	CVParam param = sp->cvParamChild(MS_scan_polarity);
-// 	res[i++] = Rcpp::wrap( (param.cvid==MS_negative_scan ? 0 : (param.cvid==MS_positive_scan ? +1 : -1 ) ) );
-	
-// 	names.push_back("peaksCount");
-//         res[i++] = Rcpp::wrap(header.peaksCount);
-//         names.push_back("totIonCurrent");
-//         res[i++] = Rcpp::wrap(header.totIonCurrent);
-//         names.push_back("retentionTime");
-//         res[i++] = Rcpp::wrap(header.retentionTime);
-//         names.push_back("basePeakMZ");
-//         res[i++] = Rcpp::wrap(header.basePeakMZ);
-//         names.push_back("basePeakIntensity");
-//         res[i++] = Rcpp::wrap(header.basePeakIntensity);
-//         names.push_back("collisionEnergy");
-//         res[i++] = Rcpp::wrap(header.collisionEnergy);
-//         names.push_back("ionisationEnergy");
-//         res[i++] = Rcpp::wrap(header.ionisationEnergy);
-//         names.push_back("lowMZ");
-//         res[i++] = Rcpp::wrap(header.lowMZ);
-//         names.push_back("highMZ");
-//         res[i++] = Rcpp::wrap(header.highMZ);
-//         names.push_back("precursorScanNum");
-//         res[i++] = Rcpp::wrap(header.precursorScanNum);
-//         names.push_back("precursorMZ");
-//         res[i++] = Rcpp::wrap(header.precursorMZ);
-//         names.push_back("precursorCharge");
-//         res[i++] = Rcpp::wrap(header.precursorCharge);
-//         names.push_back("precursorIntensity");
-//         res[i++] = Rcpp::wrap(header.precursorIntensity);
-//         names.push_back("mergedScan");
-//         res[i++] = Rcpp::wrap(header.mergedScan);
-//         names.push_back("mergedResultScanNum");
-//         res[i++] = Rcpp::wrap(header.mergedResultScanNum);
-//         names.push_back("mergedResultStartScanNum");
-//         res[i++] = Rcpp::wrap(header.mergedResultStartScanNum);
-//         names.push_back("mergedResultEndScanNum");
-//         res[i++] = Rcpp::wrap(header.mergedResultEndScanNum);
-
-// 	// delete adapter issue #64
-// 	delete adapter;
-// 	adapter = NULL;
-//         res.attr("names") = names;
-//         return res;
-//     }
-//     else
-//     {
-//         Rprintf("Warning: pwiz not yet initialized.\n ");
-//         return Rcpp::List::create( );
-//     }
-// }
 
 Rcpp::DataFrame RcppPwiz::getAllScanHeaderInfo ( )
 {
@@ -316,118 +284,8 @@ Rcpp::DataFrame RcppPwiz::getAllScanHeaderInfo ( )
             SpectrumListPtr slp = msd->run.spectrumListPtr;
             int N = slp->size();
 
-            ScanHeaderStruct scanHeader;
-            RAMPAdapter * adapter = new  RAMPAdapter(filename);
-            Rcpp::IntegerVector seqNum(N); // number in sequence observed file (1-based)
-            Rcpp::IntegerVector acquisitionNum(N); // scan number as declared in File (may be gaps)
-            Rcpp::IntegerVector msLevel(N);
-            Rcpp::IntegerVector polarity(N);
-            Rcpp::IntegerVector peaksCount(N);
-            Rcpp::NumericVector totIonCurrent(N);
-            Rcpp::NumericVector retentionTime(N);        /* in seconds */
-            Rcpp::NumericVector basePeakMZ(N);
-            Rcpp::NumericVector basePeakIntensity(N);
-            Rcpp::NumericVector collisionEnergy(N);
-            Rcpp::NumericVector ionisationEnergy(N);
-            Rcpp::NumericVector lowMZ(N);
-            Rcpp::NumericVector highMZ(N);
-            Rcpp::IntegerVector precursorScanNum(N); /* only if MS level > 1 */
-            Rcpp::NumericVector precursorMZ(N);  /* only if MS level > 1 */
-            Rcpp::IntegerVector precursorCharge(N);  /* only if MS level > 1 */
-            Rcpp::NumericVector precursorIntensity(N);  /* only if MS level > 1 */
-            //char scanType[SCANTYPE_LENGTH];
-            //char activationMethod[SCANTYPE_LENGTH];
-            //char possibleCharges[SCANTYPE_LENGTH];
-            //int numPossibleCharges;
-            //bool possibleChargesArray[CHARGEARRAY_LENGTH]; /* NOTE: does NOT include "precursorCharge" information; only from "possibleCharges" */
-            Rcpp::IntegerVector mergedScan(N);  /* only if MS level > 1 */
-            Rcpp::IntegerVector mergedResultScanNum(N); /* scan number of the resultant merged scan */
-            Rcpp::IntegerVector mergedResultStartScanNum(N); /* smallest scan number of the scanOrigin for merged scan */
-            Rcpp::IntegerVector mergedResultEndScanNum(N); /* largest scan number of the scanOrigin for merged scan */
-
-            for (int whichScan=1; whichScan <= N; whichScan++)
-            {
-                adapter->getScanHeader(whichScan - 1, scanHeader);
-                seqNum[whichScan-1] = scanHeader.seqNum;
-                acquisitionNum[whichScan-1] = scanHeader.acquisitionNum;
-                msLevel[whichScan-1] = scanHeader.msLevel;
-
-		SpectrumPtr sp = slp->spectrum(whichScan-1, true); // Is TRUE neccessary here ? 
-		CVParam param = sp->cvParamChild(MS_scan_polarity);
-		polarity[whichScan-1] = (param.cvid==MS_negative_scan ? 0 : (param.cvid==MS_positive_scan ? +1 : -1 ) );
-			
-                peaksCount[whichScan-1] = scanHeader.peaksCount;
-                totIonCurrent[whichScan-1] = scanHeader.totIonCurrent;
-                retentionTime[whichScan-1] = scanHeader.retentionTime;
-                basePeakMZ[whichScan-1] = scanHeader.basePeakMZ;
-                basePeakIntensity[whichScan-1] = scanHeader.basePeakIntensity;
-                collisionEnergy[whichScan-1] = scanHeader.collisionEnergy;
-                ionisationEnergy[whichScan-1] = scanHeader.ionisationEnergy;
-                lowMZ[whichScan-1] = scanHeader.lowMZ;
-                highMZ[whichScan-1] = scanHeader.highMZ;
-                precursorScanNum[whichScan-1] = scanHeader.precursorScanNum;
-                precursorMZ[whichScan-1] = scanHeader.precursorMZ;
-                precursorCharge[whichScan-1] = scanHeader.precursorCharge;
-                precursorIntensity[whichScan-1] = scanHeader.precursorIntensity;
-                mergedScan[whichScan-1] = scanHeader.mergedScan;
-                mergedResultScanNum[whichScan-1] = scanHeader.mergedResultScanNum;
-                mergedResultStartScanNum[whichScan-1] = scanHeader.mergedResultStartScanNum;
-                mergedResultEndScanNum[whichScan-1] = scanHeader.mergedResultEndScanNum;
-            }
-	    // delete adapter issue #64
-	    delete adapter;
-	    adapter = NULL;
-
-            Rcpp::List header(21);
-            std::vector<std::string> names;
-            int i = 0;
-            names.push_back("seqNum");
-            header[i++] = Rcpp::wrap(seqNum);
-            names.push_back("acquisitionNum");
-            header[i++] = Rcpp::wrap(acquisitionNum);
-            names.push_back("msLevel");
-            header[i++] = Rcpp::wrap(msLevel);
-            names.push_back("polarity");
-            header[i++] = Rcpp::wrap(polarity);
-            names.push_back("peaksCount");
-            header[i++] = Rcpp::wrap(peaksCount);
-            names.push_back("totIonCurrent");
-            header[i++] = Rcpp::wrap(totIonCurrent);
-            names.push_back("retentionTime");
-            header[i++] = Rcpp::wrap(retentionTime);
-            names.push_back("basePeakMZ");
-            header[i++] = Rcpp::wrap(basePeakMZ);
-            names.push_back("basePeakIntensity");
-            header[i++] = Rcpp::wrap(basePeakIntensity);
-            names.push_back("collisionEnergy");
-            header[i++] = Rcpp::wrap(collisionEnergy);
-            names.push_back("ionisationEnergy");
-            header[i++] = Rcpp::wrap(ionisationEnergy);
-            names.push_back("lowMZ");
-            header[i++] = Rcpp::wrap(lowMZ);
-            names.push_back("highMZ");
-            header[i++] = Rcpp::wrap(highMZ);
-            names.push_back("precursorScanNum");
-            header[i++] = Rcpp::wrap(precursorScanNum);
-            names.push_back("precursorMZ");
-            header[i++] = Rcpp::wrap(precursorMZ);
-            names.push_back("precursorCharge");
-            header[i++] = Rcpp::wrap(precursorCharge);
-            names.push_back("precursorIntensity");
-            header[i++] = Rcpp::wrap(precursorIntensity);
-            names.push_back("mergedScan");
-            header[i++] = Rcpp::wrap(mergedScan);
-            names.push_back("mergedResultScanNum");
-            header[i++] = Rcpp::wrap(mergedResultScanNum);
-            names.push_back("mergedResultStartScanNum");
-            header[i++] = Rcpp::wrap(mergedResultStartScanNum);
-            names.push_back("mergedResultEndScanNum");
-            header[i++] = Rcpp::wrap(mergedResultEndScanNum);
-
-			header.attr("names") = names;
-
-            allScanHeaderInfo = header;
-            isInCacheAllScanHeaderInfo = TRUE;
+            allScanHeaderInfo = getScanHeaderInfo(Rcpp::seq(1, N));
+            isInCacheAllScanHeaderInfo = TRUE;	    
         }
         return(allScanHeaderInfo);
     }

--- a/src/RcppPwiz.cpp
+++ b/src/RcppPwiz.cpp
@@ -228,6 +228,85 @@ Rcpp::List RcppPwiz::getScanHeaderInfo ( int whichScan  )
     }
 }
 
+// Rcpp::List RcppPwiz::getScanHeaderInfo ( int whichScan  )
+// {
+//     if (msd != NULL)
+//     {
+//         SpectrumListPtr slp = msd->run.spectrumListPtr;
+//         if ((whichScan <= 0) || (whichScan > slp->size()))
+//         {
+//             Rprintf("Index out of bounds [1 ... %d].\n", slp->size());
+//             return Rcpp::List::create( );
+//         }
+
+//         RAMPAdapter * adapter = new  RAMPAdapter(filename);
+//         ScanHeaderStruct header;
+//         adapter->getScanHeader(whichScan - 1, header);
+
+//         Rcpp::List res(21);
+//         std::vector<std::string> names;
+//         int i = 0;
+
+//         names.push_back("seqNum");
+//         res[i++] = Rcpp::wrap(header.seqNum);
+//         names.push_back("acquisitionNum");
+//         res[i++] = Rcpp::wrap(header.acquisitionNum);
+//         names.push_back("msLevel");
+//         res[i++] = Rcpp::wrap(header.msLevel);
+
+//         names.push_back("polarity");
+// 	SpectrumPtr sp = slp->spectrum(whichScan - 1, true); // Is TRUE neccessary here ? 
+// 	CVParam param = sp->cvParamChild(MS_scan_polarity);
+// 	res[i++] = Rcpp::wrap( (param.cvid==MS_negative_scan ? 0 : (param.cvid==MS_positive_scan ? +1 : -1 ) ) );
+	
+// 	names.push_back("peaksCount");
+//         res[i++] = Rcpp::wrap(header.peaksCount);
+//         names.push_back("totIonCurrent");
+//         res[i++] = Rcpp::wrap(header.totIonCurrent);
+//         names.push_back("retentionTime");
+//         res[i++] = Rcpp::wrap(header.retentionTime);
+//         names.push_back("basePeakMZ");
+//         res[i++] = Rcpp::wrap(header.basePeakMZ);
+//         names.push_back("basePeakIntensity");
+//         res[i++] = Rcpp::wrap(header.basePeakIntensity);
+//         names.push_back("collisionEnergy");
+//         res[i++] = Rcpp::wrap(header.collisionEnergy);
+//         names.push_back("ionisationEnergy");
+//         res[i++] = Rcpp::wrap(header.ionisationEnergy);
+//         names.push_back("lowMZ");
+//         res[i++] = Rcpp::wrap(header.lowMZ);
+//         names.push_back("highMZ");
+//         res[i++] = Rcpp::wrap(header.highMZ);
+//         names.push_back("precursorScanNum");
+//         res[i++] = Rcpp::wrap(header.precursorScanNum);
+//         names.push_back("precursorMZ");
+//         res[i++] = Rcpp::wrap(header.precursorMZ);
+//         names.push_back("precursorCharge");
+//         res[i++] = Rcpp::wrap(header.precursorCharge);
+//         names.push_back("precursorIntensity");
+//         res[i++] = Rcpp::wrap(header.precursorIntensity);
+//         names.push_back("mergedScan");
+//         res[i++] = Rcpp::wrap(header.mergedScan);
+//         names.push_back("mergedResultScanNum");
+//         res[i++] = Rcpp::wrap(header.mergedResultScanNum);
+//         names.push_back("mergedResultStartScanNum");
+//         res[i++] = Rcpp::wrap(header.mergedResultStartScanNum);
+//         names.push_back("mergedResultEndScanNum");
+//         res[i++] = Rcpp::wrap(header.mergedResultEndScanNum);
+
+// 	// delete adapter issue #64
+// 	delete adapter;
+// 	adapter = NULL;
+//         res.attr("names") = names;
+//         return res;
+//     }
+//     else
+//     {
+//         Rprintf("Warning: pwiz not yet initialized.\n ");
+//         return Rcpp::List::create( );
+//     }
+// }
+
 Rcpp::DataFrame RcppPwiz::getAllScanHeaderInfo ( )
 {
     if (msd != NULL)

--- a/src/RcppPwiz.h
+++ b/src/RcppPwiz.h
@@ -68,7 +68,12 @@ public:
 
     Rcpp::List getRunInfo();
 
-    Rcpp::List getScanHeaderInfo(int whichScan);
+    /**
+     * Reads the scan header for the provided scan(s). Note that this function
+     * no longer returns a List, but a DataFrame, even if length whichScan is 1.
+     * @return The scan header info is returned as a Rcpp::DataFrame
+     **/
+    Rcpp::DataFrame getScanHeaderInfo(Rcpp::IntegerVector whichScan);
 
     Rcpp::DataFrame getChromatogramsInfo(int whichChrom);
 

--- a/src/RcppPwizModule.cpp
+++ b/src/RcppPwizModule.cpp
@@ -14,7 +14,7 @@ RCPP_MODULE(Pwiz)
     //.method( "writeMSfile", &RcppPwiz::writeMSfile, "Write a pwiz object into files (mzXML, mzData, etc.)" )
     .method( "getFilename", &RcppPwiz::getFilename, "Returns the mass spec filename.")
     .method( "getInstrumentInfo", &RcppPwiz::getInstrumentInfo, "Reads the instrument information from a pwiz object" )
-    .method( "getScanHeaderInfo", &RcppPwiz::getScanHeaderInfo, "Reads the header info for one mass spectrum." )
+    .method( "getScanHeaderInfo", &RcppPwiz::getScanHeaderInfo, "Reads the header info for the specified scan(s). Supports also to extract scan header infos for multiple scans." )
     .method( "getChromatogramsInfo", &RcppPwiz::getChromatogramsInfo, "Reads the chromatogram information.")
     .method( "getPeakList", &RcppPwiz::getPeakList,
              "Performs a non-sequential parsing operation on an indexed mzXML file to obtain the peak list for a numbered scan." )


### PR DESCRIPTION
This pull request contains the new implementations for the `getScanHeaderInfo` and `getAllScanHeaderInfo` of the `pwiz` backend.
It fixes issues #106 in `mzR` and https://github.com/lgatto/MSnbase/issues/216 in `MSnbase`.

I added also a unit test to ensure that the header that is read by the new implementations matches the one which would be read using the `Ramp` backend.