### PR TITLE
Report ion injection time in header of pwiz backend

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 CHANGES IN VERSION 2.11.3
 -------------------------
- o Nothing yet
+ o Read ion injection time from mzML files and add it to the data.frame returned
+   by the header function.
  
 CHANGES IN VERSION 2.11.2
 -------------------------

--- a/R/methods-mzRnetCDF.R
+++ b/R/methods-mzRnetCDF.R
@@ -91,7 +91,8 @@ setMethod("header",
                             mergedScan=rep(-1, length(scans)),
                             mergedResultScanNum=rep(-1, length(scans)),
                             mergedResultStartScanNum=rep(-1, length(scans)),
-                            mergedResultEndScanNum=rep(-1, length(scans)))
+                            mergedResultEndScanNum=rep(-1, length(scans)),
+                            injectionTime = rep(-1, length(scans)))
 
             return(result)
           })

--- a/inst/unitTests/test_cdf.R
+++ b/inst/unitTests/test_cdf.R
@@ -40,15 +40,15 @@ test_header <- function() {
   cdf <- openMSfile(file, backend="netCDF")        
 
   h <- header(cdf)
-  checkEquals(ncol(h), 19)
+  checkEquals(ncol(h), 20)
   checkEquals(nrow(h), 1278)
 
   h <- header(cdf, 1)
-  checkEquals(ncol(h), 19)
+  checkEquals(ncol(h), 20)
   checkEquals(nrow(h), 1)
 
   h <- header(cdf, 2:3)
-  checkEquals(ncol(h), 19)
+  checkEquals(ncol(h), 20)
   checkEquals(nrow(h), 2)
 
   close(cdf)

--- a/inst/unitTests/test_injection_time.R
+++ b/inst/unitTests/test_injection_time.R
@@ -1,0 +1,40 @@
+test_injection_time <- function() {
+    library(msdata)
+    library(mzR)
+    library(RUnit)
+    ## mzXML
+    fl <- system.file("threonine", "threonine_i2_e35_pH_tree.mzXML",
+                      package = "msdata")
+    mzxml <- openMSfile(fl, backend = "pwiz")
+    hdr <- header(mzxml)
+    mzR::close(mzxml)
+    checkTrue(all(hdr$injectionTime == 0))
+    checkTrue(any(colnames(hdr) == "injectionTime"))
+    fl <- system.file("threonine", "threonine_i2_e35_pH_tree.mzXML",
+                      package = "msdata")
+    mzxml <- openMSfile(fl, backend = "Ramp")
+    hdr <- header(mzxml)
+    mzR::close(mzxml)
+    checkTrue(all(hdr$injectionTime == 0))
+    checkTrue(any(colnames(hdr) == "injectionTime"))
+
+    ## CDF
+    fl <- system.file("cdf", "ko15.CDF",
+                      package = "msdata")
+    mzxml <- openMSfile(fl, backend = "netCDF")
+    hdr <- header(mzxml)
+    mzR::close(mzxml)
+    checkTrue(all(hdr$injectionTime == -1))
+    checkTrue(any(colnames(hdr) == "injectionTime"))
+
+    ## mzML - with injection time present.
+    fl <- system.file("proteomics",
+                      "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzML.gz",
+                      package = "msdata")
+    mzxml <- openMSfile(fl, backend = "pwiz")
+    hdr <- header(mzxml)
+    mzR::close(mzxml)
+    checkTrue(all(hdr$injectionTime != 0))
+    checkTrue(any(colnames(hdr) == "injectionTime"))
+    
+}

--- a/inst/unitTests/test_pwiz.R
+++ b/inst/unitTests/test_pwiz.R
@@ -124,20 +124,23 @@ test_getScanHeaderInfo <- function() {
     ## Read single scan header.
     scan_3 <- header(mzml, scans = 3)
     scan_3_ramp <- header(ramp, scans = 3)
-    ## Ramp does not read polarity
+    ## Ramp does not read polarity or injectionTime
     scan_3$polarity <- 0
+    scan_3$injectionTime <- 0
     checkEquals(scan_3, scan_3_ramp)
     
     ## Read all scan header
     all_scans <- header(mzml)
     all_scans_ramp <- header(ramp)
     all_scans$polarity <- 0
+    all_scans$injectionTime <- 0
     checkEquals(all_scans, all_scans_ramp)
     
     ## passing the index of all scan headers should return the same
     all_scans_2 <- header(mzml, scans = 1:nrow(all_scans))
     all_scans_ramp_2 <- header(ramp, scans = 1:nrow(all_scans))
     all_scans_2$polarity <- 0
+    all_scans_2$injectionTime <- 0
     checkEquals(all_scans, all_scans_2)
     checkEquals(as.list(all_scans[3, ]), scan_3)
     checkEquals(all_scans_2, all_scans_ramp_2)
@@ -147,6 +150,7 @@ test_getScanHeaderInfo <- function() {
     scan_3_ramp <- header(ramp, scans = c(3, 1, 14))
     ## Ramp does not read polarity
     scan_3$polarity <- 0
+    scan_3$injectionTime <- 0
     checkEquals(scan_3, scan_3_ramp)
 
     close(mzml)

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -97,7 +97,8 @@
   \code{precursorScanNum}, \code{precursorMZ}, \code{precursorCharge},
   \code{precursorIntensity}, \code{mergedScan},
   \code{mergedResultScanNum}, \code{mergedResultStartScanNum} and
-  \code{mergedResultEndScanNum}, when available in the original file. If
+  \code{mergedResultEndScanNum}, \code{injectionTime} (ion injection
+  time) when available in the original file. If
   multiple scans are queried, a \code{data.frame} is returned with the
   scans reported along the rows.
 

--- a/src/RcppPwiz.cpp
+++ b/src/RcppPwiz.cpp
@@ -186,6 +186,7 @@ Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan)
       Rcpp::IntegerVector mergedResultScanNum(N_scans); /* scan number of the resultant merged scan */
       Rcpp::IntegerVector mergedResultStartScanNum(N_scans); /* smallest scan number of the scanOrigin for merged scan */
       Rcpp::IntegerVector mergedResultEndScanNum(N_scans); /* largest scan number of the scanOrigin for merged scan */
+      Rcpp::NumericVector ionInjectionTime(N_scans); /* The time spent filling an ion trapping device*/
       
       for (int i = 0; i < N_scans; i++)
 	{
@@ -196,9 +197,13 @@ Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan)
 	  msLevel[i] = scanHeader.msLevel;
 	  
 	  SpectrumPtr sp = slp->spectrum(current_scan-1, false); // Is TRUE neccessary here ? 
+	  Scan dummy;
+	  Scan& scan = sp->scanList.scans.empty() ? dummy : sp->scanList.scans[0];
 	  CVParam param = sp->cvParamChild(MS_scan_polarity);
 	  polarity[i] = (param.cvid==MS_negative_scan ? 0 : (param.cvid==MS_positive_scan ? +1 : -1 ) );
-	  
+	  // ionInjectionTime[i] = sp->cvParam(MS_ion_injection_time).valueAs<double>();
+	  ionInjectionTime[i] = scan.cvParam(MS_ion_injection_time).timeInSeconds();
+
 	  peaksCount[i] = scanHeader.peaksCount;
 	  totIonCurrent[i] = scanHeader.totIonCurrent;
 	  retentionTime[i] = scanHeader.retentionTime;
@@ -221,7 +226,7 @@ Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan)
       delete adapter;
       adapter = NULL;
       
-      Rcpp::List header(21);
+      Rcpp::List header(22);
       std::vector<std::string> names;
       int i = 0;
       names.push_back("seqNum");
@@ -266,6 +271,8 @@ Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan)
       header[i++] = Rcpp::wrap(mergedResultStartScanNum);
       names.push_back("mergedResultEndScanNum");
       header[i++] = Rcpp::wrap(mergedResultEndScanNum);
+      names.push_back("injectionTime");
+      header[i++] = Rcpp::wrap(ionInjectionTime);
       
       header.attr("names") = names;
       

--- a/src/RcppRamp.cpp
+++ b/src/RcppRamp.cpp
@@ -148,7 +148,7 @@ Rcpp::List RcppRamp::getScanHeaderInfo ( int whichScan  )
         delete info;
 
         std::vector<std::string> names;
-        Rcpp::List header(21);
+        Rcpp::List header(22);
         int i = 0;
 
         names.push_back("seqNum");
@@ -193,6 +193,8 @@ Rcpp::List RcppRamp::getScanHeaderInfo ( int whichScan  )
         header[i++] = Rcpp::wrap(data.mergedResultStartScanNum);
         names.push_back("mergedResultEndScanNum");
         header[i++] = Rcpp::wrap(data.mergedResultEndScanNum);
+        names.push_back("injectionTime");
+        header[i++] = 0;
 
         header.attr("names") = names;
 
@@ -260,7 +262,7 @@ Rcpp::DataFrame RcppRamp::getAllScanHeaderInfo ( )
                 mergedResultEndScanNum[whichScan-1] = scanHeader.mergedResultEndScanNum;
             }
 
-            Rcpp::List header(21);
+            Rcpp::List header(22);
             std::vector<std::string> names;
             int i = 0;
 
@@ -306,6 +308,8 @@ Rcpp::DataFrame RcppRamp::getAllScanHeaderInfo ( )
             header[i++] =Rcpp::wrap(mergedResultStartScanNum);
             names.push_back("mergedResultEndScanNum");
             header[i++] =Rcpp::wrap(mergedResultEndScanNum);
+            names.push_back("injectionTime");
+            header[i++] = 0;
             
 			header.attr("names") = names;
 			


### PR DESCRIPTION
- Add a column injectionTime to the data.frame returned by the header
  function (all backends).
- Pwiz backend extracts the ion injection time.
- Update relevant documentation and add unit test(s).

This would fix (hopefully) https://github.com/lgatto/MSnbase/issues/221 . Note: injection time was first introduced in `MSnbase` due to this issue: https://github.com/lgatto/MSnbase/issues/159