### PR TITLE
Restoring and correcting mz5 support

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -34,17 +34,26 @@ PWIZOBJECTS=\
 ./pwiz/data/common/BinaryIndexStream.o \
 ./pwiz/data/common/diff_std.o \
 ./pwiz/data/common/Unimod.o \
+./pwiz/data/msdata/mz5/Configuration_mz5.o \
+./pwiz/data/msdata/mz5/Connection_mz5.o \
+./pwiz/data/msdata/mz5/Datastructures_mz5.o \
+./pwiz/data/msdata/mz5/ReferenceRead_mz5.o \
+./pwiz/data/msdata/mz5/ReferenceWrite_mz5.o \
+./pwiz/data/msdata/mz5/Translator_mz5.o \
 ./pwiz/data/msdata/SpectrumList_MGF.o \
 ./pwiz/data/msdata/DefaultReaderList.o \
 ./pwiz/data/msdata/ChromatogramList_mzML.o \
+./pwiz/data/msdata/ChromatogramList_mz5.o \
 ./pwiz/data/msdata/examples.o \
 ./pwiz/data/msdata/Serializer_mzML.o \
 ./pwiz/data/msdata/Serializer_MSn.o \
 ./pwiz/data/msdata/Reader.o \
+./pwiz/data/msdata/Serializer_mz5.o \
 ./pwiz/data/msdata/Serializer_MGF.o \
 ./pwiz/data/msdata/Serializer_mzXML.o \
 ./pwiz/data/msdata/SpectrumList_mzML.o \
 ./pwiz/data/msdata/SpectrumList_MSn.o \
+./pwiz/data/msdata/SpectrumList_mz5.o \
 ./pwiz/data/msdata/BinaryDataEncoder.o \
 ./pwiz/data/msdata/Diff.o \
 ./pwiz/data/msdata/MSData.o \
@@ -125,13 +134,13 @@ OBJECTS= $(MZROBJECTS) $(PWIZOBJECTS) $(ARCH_OBJS) rampR.o R_init_mzR.o
 ##  http://www.gamedev.net/topic/555511-is-there-a-way-to-only-disable-boost-debug-checks/
 ##
 
-PWIZ_CPPFLAGS=-I./boost_aux/ -I./boost/ -I. -D_LARGEFILE_SOURCE -DHAVE_PWIZ_MZML_LIB -D_NODEBUG -DWITHOUT_MZ5  
-PWIZ_LDFLAGS=-lpthread 
+PWIZ_CPPFLAGS=-I./boost_aux/ -I./boost/ -I. -D_LARGEFILE_SOURCE -DHAVE_PWIZ_MZML_LIB -D_NODEBUG
+PWIZ_LDFLAGS=-lhdf5_cpp -lpthread
 
 ## Use the R_HOME indirection to support installations of multiple R version
 PKG_CPPFLAGS=$(PWIZ_CPPFLAGS) $(NC_CFLAGS)  $(ARCH_CPPFLAGS)
 
-PKG_LIBS=$(NC_LIBS)  $(ARCH_LIBS) 
+PKG_LIBS=$(PWIZ_LDFLAGS) $(NC_LIBS)  $(ARCH_LIBS)
 
 all: clean $(SHLIB)
 


### PR DESCRIPTION
For some reasons mz5 support was removed and re-added a few times during the
summer of 2014 - mz5 support was removed in May 26 18:28:05 2014,
                 added back in Jun 25 22:13:35 2014,
                 and removed again in July 11 01:48:50 2014. -
and resulted in its removal at the end of the summer at the merge
of the GSoC work [1]. No reason was mentioned.

The only reason I can think of, is that libhdf5_cpp is rare.

So this change add it back, and also fixes a somewhat stylistic issue
where PWIZ_LDFLAGS is defined but PKG_LIBS was not referring to it.

[1]
commit 84a4b1664f27a82bf12957dadc86443dd7c38705
Author: s.neumann <s.neumann@bc3139a8-67e5-0310-9ffc-ced21a209358>
Date:   Sun Sep 28 18:06:01 2014 +0000

    Commit made by the Bioconductor Git-SVN bridge.
    Consists of 130 commits.

    Commit information:

    Commit id: 289dc240065888efcaa22ae75951e81f94fc800f

        Fix package description after merge

    Committed by: Steffen Neumann
    Author Name: Steffen Neumann
    Commit date: 2014-09-28 17:21:35 +0200
    Author date: 2014-09-28 17:21:35 +0200

    Commit id: 88248e8d6d86bb54dc260f0c55608dd1a949ade4

        merged gsoc into master

...
    Committed by: qkou
    Author Name: qkou
    Commit date: 2014-07-11 01:48:50 -0400
    Author date: 2014-07-11 01:48:50 -0400

    Commit id: 5f49d13b736cebd65484a5993cdcce253853d4e7

        remove mz5

Closes https://github.com/sneumann/mzR/issues/118