### PR TITLE
Preserve precursor data in writeMSData

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
-CHANGES IN VERSION 2.11.10
+CHANGES IN VERSION 2.11.11
 --------------------------
- o Nothing yet
+ o Fix problem in writeMSData: ensure precursor data is saved even if precursor
+   scan is not available (see MSnbase issue #245).
  
 CHANGES IN VERSION 2.11.10
 --------------------------

--- a/src/RcppPwiz.cpp
+++ b/src/RcppPwiz.cpp
@@ -671,13 +671,24 @@ void RcppPwiz::addSpectrumList(MSData& msd,
     }
     // MSn - precursor:
     if (precursorScanNum[i] > 0 | precursorMZ[i] > 0) {
+      // Fill precursor data. This preserves the precursor data even if the
+      // precursor scan is not available (e.g. after MS level filtering).
+      spct.precursors.resize(1);
+      Precursor& prec = spct.precursors.front();
+      if (collisionEnergy[i] != 0) {
+	prec.activation.set(MS_collision_induced_dissociation);
+	prec.activation.set(MS_collision_energy, collisionEnergy[i],
+			    UO_electronvolt);
+      }
+      prec.selectedIons.resize(1);
+      prec.selectedIons[0].set(MS_selected_ion_m_z, precursorMZ[i], MS_m_z);
+      prec.selectedIons[0].set(MS_peak_intensity, precursorIntensity[i],
+			       MS_number_of_detector_counts);
+      prec.selectedIons[0].set(MS_charge_state, precursorCharge[i]);
       // Get the spectrumId of the precursor. Assuming that precursorScanNum is
       // linked to the acquisitionNum of the precursor.
       // This seems to be correct, since both the acquisitionNum and the
       // precursorNum are extracted from the respective spectrum's ID.
-      // Also, if we DON'T find the precursorScanNum among the acquisitionNum
-      // we skip adding the precursor data. Might be that the MS data has been
-      // filtered and the precursor scan is not provided.
       precursor_idx = -1;
       for (int j = 0; j < spctr_data.size(); j++) {
 	if (precursorScanNum[i] == acquisitionNum[j]) {
@@ -686,19 +697,7 @@ void RcppPwiz::addSpectrumList(MSData& msd,
 	}
       }
       if (precursor_idx >= 0) {
-	spct.precursors.resize(1);
-	Precursor& prec = spct.precursors.front();
 	prec.spectrumID = spectrumId[precursor_idx];
-	if (collisionEnergy[i] > 0) {
-	  prec.activation.set(MS_collision_induced_dissociation);
-	  prec.activation.set(MS_collision_energy, collisionEnergy[i],
-			      UO_electronvolt);
-	}
-	prec.selectedIons.resize(1);
-	prec.selectedIons[0].set(MS_selected_ion_m_z, precursorMZ[i], MS_m_z);
-	prec.selectedIons[0].set(MS_peak_intensity, precursorIntensity[i],
-				 MS_number_of_detector_counts);
-	prec.selectedIons[0].set(MS_charge_state, precursorCharge[i]);
       }
     }
     // [X] collisionEnergy


### PR DESCRIPTION
Ensure that precursorMz, precursorCharge and precursorIntensity are exported even if the original precursor scan is not available.

This fixes issue https://github.com/lgatto/MSnbase/issues/256