### PR TITLE
openMSFile chooses backend based on file name and eventually file content

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.13.0
+Version: 2.13.1
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou
 Maintainer: Bernd Fischer <b.fischer@dkfz.de>,
 	    Steffen Neumann <sneumann@ipb-halle.de>,

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
-CHANGES IN VERSION 2.11.12
+CHANGES IN VERSION 2.13.1
 --------------------------
- o Nothing yet
+ o openMsFile automatically determine the backend to use based on file extension
+   and content.
  
 CHANGES IN VERSION 2.11.11
 --------------------------

--- a/man/openMSfile.Rd
+++ b/man/openMSfile.Rd
@@ -9,7 +9,7 @@
   Create and check mzR objects from netCDF, mzXML, mzData or mzML files.
 }
 \usage{
- openMSfile(filename, backend=c("pwiz", "Ramp", "netCDF"), verbose = FALSE)
+ openMSfile(filename, backend = NULL, verbose = FALSE)
 
  initializeRamp(object)
 
@@ -20,10 +20,17 @@
  openIDfile(filename, verbose = FALSE)
 }
 \arguments{
-  \item{filename}{ Path name of the netCDF, mzData, mzXML or mzML file to
-    read/write. }
-  \item{backend}{ A \code{character} specifiying with backend API to
-    use. Currently 'Ramp', 'netCDF'  and 'pwiz' (default) are available.}
+  \item{filename}{
+    Path name of the netCDF, mzData, mzXML or mzML file to
+    read/write.
+  }
+  \item{backend}{
+    A \code{character(1)} specifiying which backend API to
+    use. Currently 'Ramp', 'netCDF'  and 'pwiz' are supported. If
+    \code{backend = NULL} (the default), the function tries to determine
+    the backend to be used based on either the file extension of the
+    file content.
+  }
   \item{object}{ An instantiated mzR object. }
   \item{verbose}{ Enable verbose output. }
   \item{...}{ Additional arguments, currently ignored. }

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -45,9 +45,9 @@
 
  peaksCount(object, scans, ...)
 
- peaks(object, ...) 
+ peaks(object, scans, ...) 
 
- spectra(object, ...) ## same as peaks
+ spectra(object, scans,...) ## same as peaks
 
  get3Dmap(object, scans, lowMz, highMz, resMz, ...)
 

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -45,9 +45,9 @@
 
  peaksCount(object, scans, ...)
 
- peaks(object, scans, ...) 
+ peaks(object, ...) 
 
- spectra(object, scans,...) ## same as peaks
+ spectra(object, ...) ## Same as peaks
 
  get3Dmap(object, scans, lowMz, highMz, resMz, ...)
 


### PR DESCRIPTION
If `backend` is not specified (the default), `openMsFile` selects the backend based on the file extension and eventually file content.
The relevant code was moved over from `MSnbase` and `xcms`.

Once this pull request is in `MSnbase` (and eventually `xcms`) have to be changed accordingly.