### PR TITLE
Add chromatogramHeader method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.13.1
+Version: 2.13.2
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou
 Maintainer: Bernd Fischer <b.fischer@dkfz.de>,
 	    Steffen Neumann <sneumann@ipb-halle.de>,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,9 +3,8 @@ Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
 Version: 2.13.2
-Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou
-Maintainer: Bernd Fischer <b.fischer@dkfz.de>,
-	    Steffen Neumann <sneumann@ipb-halle.de>,
+Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
+Maintainer: Steffen Neumann <sneumann@ipb-halle.de>,
 	    Laurent Gatto <lg390@cam.ac.uk>,
 	    Qiang Kou <qkou@umail.iu.edu>
 Description: mzR provides a unified API to the common file formats and

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -47,6 +47,7 @@ exportMethods(close,
               tic,
               chromatogram,
               chromatograms,
+              chromatogramHeader,
               writeMSData)
 
 exportClasses("mzR",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 2.13.2
+--------------------------
+ o Add chromatogramHeader method to read header information for chromatograms
+   from an mzML file.
+
 CHANGES IN VERSION 2.13.1
 --------------------------
  o Read filter string from mzML files and add it to the data.frame returned by

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -13,6 +13,8 @@ setGeneric("writeMSfile", function(object, filename, outformat) standardGeneric(
 ##            function(object, filename, outformat, header, data)
 ##                standardGeneric("writeSpectrumList"))
 setGeneric("chromatogramsInfo", function(object) standardGeneric("chromatogramsInfo"))
+setGeneric("chromatogramHeader", function(object, chrom)
+    standardGeneric("chromatogramHeader"))
 setGeneric("creationDate", function(object) standardGeneric("creationDate"))
 setGeneric("manufacturer", function(object) standardGeneric("manufacturer"))
 setGeneric("model", function(object) standardGeneric("model"))

--- a/R/methods-mzRpwiz.R
+++ b/R/methods-mzRpwiz.R
@@ -198,3 +198,19 @@ setMethod("chromatogram", "mzRpwiz",
               }
               return(ans)
           })
+
+setMethod("chromatogramHeader", "mzRpwiz",
+          function(object, chrom) {
+              if (missing(chrom)) {
+                  res <- object@backend$getAllChromatogramHeaderInfo()
+              } else {
+                  stopifnot(is.numeric(chrom))
+                  n <- nChrom(object)
+                  if (min(chrom) < 1 || max(chrom) > n)
+                      stop("Index out of bound [", 1, ":", n, "]")
+                  chrom <- chrom -1L
+                  res <- object@backend$getChromatogramHeaderInfo(chrom)
+              }
+              res$chromatogramId <- as.character(res$chromatogramId)
+              res
+          })

--- a/inst/unitTests/test_chromatograms.R
+++ b/inst/unitTests/test_chromatograms.R
@@ -21,3 +21,36 @@ test_chromatograms2 <- function() {
     checkIdentical(tic(x), chromatogram(x, 1L))
     checkIdentical(nrow(tic(x)), 7534L)
 }
+
+test_chromatogramHeader <- function() {
+    library(mzR)
+    library(RUnit)
+    library(msdata)
+    
+    f <- proteomics(full.names = TRUE, pattern = "MRM")
+    x <- openMSfile(f)
+
+    chrs <- chromatogram(x)
+    ch <- chromatogramHeader(x)
+    checkEquals(colnames(ch), c("chromatogramId", "chromatogramIndex", "polarity",
+                                "precursorIsolationWindowTargetMZ",
+                                "precursorIsolationWindowLowerOffset",
+                                "precursorIsolationWindowUpperOffset",
+                                "precursorCollisionEnergy",
+                                "productIsolationWindowTargetMZ",
+                                "productIsolationWindowLowerOffset",
+                                "productIsolationWindowUpperOffset"))
+    checkEquals(ch$chromatogramId[1], "TIC")
+    checkEquals(sum(is.na(ch$precursorIsolationWindowTargetMZ)), 1)
+    checkEquals(sum(is.na(ch$productIsolationWindowTargetMZ)), 1)    
+    checkEquals(length(chrs), nrow(ch))
+    close(x)
+
+    ## Should return only the TIC.
+    f <- proteomics(full.names = TRUE, pattern = "MS3")
+    x <- openMSfile(f)
+    ch <- chromatogramHeader(x)
+    checkEquals(nrow(ch), 1)
+    checkEquals(ch$chromatogramId, "TIC")
+    close(x)
+}

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -27,10 +27,12 @@
 \alias{get3Dmap,mzRpwiz-method}
 
 \alias{chromatogram,mzRpwiz-method}
+\alias{chromatogramHeader,mzRpwiz-method}
 \alias{chromatograms,mzRpwiz-method}
 \alias{tic,mzRpwiz-method}
 \alias{nChrom}
 \alias{chromatogram}
+\alias{chromatogramHeader}
 \alias{chromatograms}
 \alias{tic}
 
@@ -59,6 +61,8 @@
 
  chromatograms(object, ...) ## same as chromatogram
 
+ \S4method{chromatogramHeader}{mzRpwiz}(object, chrom)
+
  tic(object, ...)
 
  nChrom(object)
@@ -78,6 +82,12 @@
     returned.}
   
   \item{resMz}{a \code{numeric} defining the m/z resolution.}
+
+  \item{chrom}{
+    For \code{chromatogramHeader}: \code{numeric} specifying the index
+    of the chromatograms to be extracted from the file. If omitted, data
+    for all chromatograms is returned. 
+  }
   
   \item{...}{Other arguments. A \code{scan} parameter can be passed to
     \code{peaks}.}  }
@@ -128,6 +138,23 @@
   The \code{nChrom} function returns the number of chromatograms,
   including the total ion chromatogram.
 
+  The \code{chromatogramHeader} returns (similar to the \code{header}
+  function for spectra) a \code{data.frame} with metadata information
+  for the individual chromatograms. The \code{data.frame} has the
+  columns: \code{"chromatogramId"} (the ID of the chromatogram as
+  specified in the file), \code{"chromatogramIndex"} (the index of the
+  chromatogram within the file), \code{"polarity"} (the polarity for the
+  chromatogram, 0 for negative, +1 for positive and -1 for not set),
+  \code{"precursorIsolationWindowTargetMZ"} (the isolation window m/z of
+  the precursor), \code{"precursorIsolationWindowLowerOffset"},
+  \code{"precursorIsolationWindowUpperOffset"} (lower and upper offset
+  for the isolation window m/z), \code{"precursorCollisionEnergy"}
+  (collision energy),
+  \code{"productIsolationWindowTargetMZ"},
+  \code{"productIsolationWindowLowerOffset"} and
+  \code{"productIsolationWindowUpperOffset"} (definition of the m/z
+  isolation window for the product).
+  
   Note that access to chromatograms is only supported in the \code{pwiz}
   backend.
   
@@ -202,4 +229,8 @@
  head(tic(x))
  head(chromatogram(x, 1L)) ## same as tic(x)
  str(chromatogram(x, 10:12))  
+
+ ## get the header information for the chromatograms
+ ch <- chromatogramHeader(x)
+ head(ch)
 }

--- a/src/RcppPwiz.h
+++ b/src/RcppPwiz.h
@@ -90,9 +90,13 @@ public:
      **/
     Rcpp::DataFrame getScanHeaderInfo(Rcpp::IntegerVector whichScan);
 
+    Rcpp::DataFrame getChromatogramHeaderInfo(Rcpp::IntegerVector whichScan);
+
     Rcpp::DataFrame getChromatogramsInfo(int whichChrom);
 
     Rcpp::DataFrame getAllScanHeaderInfo();
+
+    Rcpp::DataFrame getAllChromatogramHeaderInfo();
 
     Rcpp::List getPeakList(int whichScan);
 

--- a/src/RcppPwizModule.cpp
+++ b/src/RcppPwizModule.cpp
@@ -25,5 +25,7 @@ RCPP_MODULE(Pwiz)
     .method( "get3DMap", &RcppPwiz::get3DMap, "Reads all scans and returns them as a matrix." )
     .method( "getLastScan", &RcppPwiz::getLastScan, "Returns the last scan (not necessarily the number of scans because of missing scans)." )
     .method( "getLastChrom", &RcppPwiz::getLastChrom, "Returns the index of the last chromatogram." )
+    .method("getChromatogramHeaderInfo", &RcppPwiz::getChromatogramHeaderInfo, "Returns a data.frame with the chromatogram header information")
+    .method("getAllChromatogramHeaderInfo", &RcppPwiz::getAllChromatogramHeaderInfo, "Returns a data.frame with the header for all chromatograms")
     ;
 }


### PR DESCRIPTION
- Add a chromatogramHeader method to extract chromatogram header information from an mzML file (issue #141).
- Unit test and documentation added.

Side note: eventually I might merit being added to the contributors of the package ;)