### PR TITLE
Fix endian.hpp for new c++ versions

### DIFF
--- a/src/pwiz/utility/misc/endian.hpp
+++ b/src/pwiz/utility/misc/endian.hpp
@@ -43,6 +43,7 @@ namespace util {
 
 
 #if (defined(PWIZ_GCC) && defined(__BYTE_ORDER) && __BYTE_ORDER==__LITTLE_ENDIAN) || \
+    (defined(PWIZ_GCC) && defined(__BYTE_ORDER__) && __BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__) || \
     (defined(__DARWIN_BYTE_ORDER) && __DARWIN_BYTE_ORDER==__DARWIN_LITTLE_ENDIAN) || \
     (defined(__LITTLE_ENDIAN__)) || \
     (defined(__MINGW32__)) || \
@@ -52,7 +53,8 @@ namespace util {
 #endif
 
 
-#if (defined(PWIZ_GCC) && defined(__BYTE_ORDER) && __BYTE_ORDER==__BIG_ENDIAN)
+#if (defined(PWIZ_GCC) && defined(__BYTE_ORDER) && __BYTE_ORDER==__BIG_ENDIAN) || \
+    (defined(PWIZ_GCC) && defined(__BYTE_ORDER__) && __BYTE_ORDER__==__ORDER_BIG_ENDIAN__)
 #define PWIZ_BIG_ENDIAN
 #endif
 


### PR DESCRIPTION
Hi, there is the fix to be able to compile on new gcc versions.
The macro for byte order is now: `__BYTE_ORDER__`
The macro for little endian is now: `__ORDER_LITTLE_ENDIAN__`
The macro for big endian is now:` __ORDER_BIG_ENDIAN__`

This pull maintains the retro-compatibility while adding new versions compatibility!