### PR TITLE
Add .hasChromatograms function (issue #164)

### DIFF
--- a/R/methods-mzRnetCDF.R
+++ b/R/methods-mzRnetCDF.R
@@ -169,3 +169,13 @@ setMethod("show",
             invisible(NULL)
           })
 
+setMethod("chromatograms", "mzRnetCDF", function(object, chrom)
+    chromatogram(object, chrom))
+setMethod("chromatogram", "mzRnetCDF", function(object, chrom) {
+    warning("The mzRnetCdf backend does not support chromatographic data")
+    .empty_chromatogram()
+})
+setMethod("chromatogramHeader", "mzRnetCDF", function(object, chrom) {
+    warning("The mzRnetCdf backend does not support chromatographic data")
+    .empty_chromatogram_header()
+})

--- a/R/methods-mzRramp.R
+++ b/R/methods-mzRramp.R
@@ -163,3 +163,14 @@ setMethod("show",
 
 setMethod("isolationWindow", "mzRramp",
           function(object, ...) .isolationWindow(fileName(object), ...))
+
+setMethod("chromatograms", "mzRramp", function(object, chrom)
+    chromatogram(object, chrom))
+setMethod("chromatogram", "mzRramp", function(object, chrom) {
+    warning("The mzRnetCdf backend does not support chromatographic data")
+    .empty_chromatogram()
+})
+setMethod("chromatogramHeader", "mzRramp", function(object, chrom) {
+    warning("The mzRnetCdf backend does not support chromatographic data")
+    .empty_chromatogram_header()
+})

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,8 +43,56 @@ setMethod("isolationWindow", "character",
 
 
 .hasSpectra <- function(x) {
-    if (is.character(x) & file.exists(x))
+    close_after <- FALSE
+    if (is.character(x) && file.exists(x)) {
         x <- mzR::openMSfile(x)
+        ## Ensure we are closing the file later
+        close_after <- TRUE
+    }
     stopifnot(inherits(x, "mzR"))
-    return(as.logical(length(x)))
+    len <- length(x)
+    if (close_after)
+        close(x)
+    return(as.logical(len))
+}
+
+#' Create return data for MS backends not supporting chromatographic data. This
+#' function is supposed to be called by the chromatogram(s) methods for these
+#' backends
+#'
+#' @author Johannes Rainer
+#'
+#' @noRd
+.empty_chromatogram <- function() {
+    list()
+}
+
+#' Create return data for MS backends not supporting chromatographic data.
+#'
+#' @author Johannes Rainer
+#'
+#' @noRd
+.empty_chromatogram_header <- function() {
+    cn <- c("chromatogramId", "chromatogramIndex", "polarity",
+            "precursorIsolationWindowTargetMZ",
+            "precursorIsolationWindowLowerOffset",
+            "precursorIsolationWindowUpperOffset",
+            "precursorCollisionEnergy", "productIsolationWindowTargetMZ",
+            "productIsolationWindowLowerOffset",
+            "productIsolationWindowUpperOffset")
+    data.frame(matrix(nrow = 0, ncol = length(cn),
+                      dimnames = list(character(), cn)))
+}
+
+.hasChromatograms <- function(x) {
+    close_after <- FALSE
+    if (is.character(x) && file.exists(x)) {
+        x <- mzR::openMSfile(x)
+        close_after <- TRUE
+    }
+    stopifnot(inherits(x, "mzR"))
+    hdr <- chromatogramHeader(x)
+    if (close_after)
+        close(x)
+    as.logical(nrow(hdr))
 }

--- a/inst/unitTests/test_cdf.R
+++ b/inst/unitTests/test_cdf.R
@@ -58,3 +58,27 @@ test_header <- function() {
 
   close(cdf)
 }
+
+test_chromatogram <- function() {
+    file <- system.file('cdf/ko15.CDF', package = "msdata")
+    x <- openMSfile(file, backend="netCDF")        
+    suppressWarnings(
+        chr <- chromatogram(x)
+    )
+    checkTrue(length(chr) == 0)
+    suppressWarnings(
+        chr <- chromatograms(x)
+    )
+    checkTrue(length(chr) == 0)
+    close(x)
+}
+
+test_chromatogramHeader <- function() {
+    file <- system.file('cdf/ko15.CDF', package = "msdata")
+    x <- openMSfile(file, backend="netCDF")        
+    suppressWarnings(
+        ch <- chromatogramHeader(x)
+    )
+    checkTrue(nrow(ch) == 0)
+    close(x)
+}

--- a/inst/unitTests/test_ramp.R
+++ b/inst/unitTests/test_ramp.R
@@ -102,4 +102,32 @@ test_peaks_spectra <- function() {
     p <- peaks(x, 1:10)
     s <- spectra(x, 1:10)
     checkIdentical(p, s)
+    close(x)
 }
+
+test_chromatogram <- function() {
+    library("msdata")
+    f <- proteomics(full.names = TRUE)
+    x <- openMSfile(f[1], backend = "Ramp")
+    suppressWarnings(
+        chr <- chromatogram(x)
+    )
+    checkTrue(length(chr) == 0)
+    suppressWarnings(
+        chr <- chromatograms(x)
+    )
+    checkTrue(length(chr) == 0)
+    close(x)
+}
+
+test_chromatogramHeader <- function() {
+    library("msdata")
+    f <- proteomics(full.names = TRUE)
+    x <- openMSfile(f[1], backend = "Ramp")
+    suppressWarnings(
+        ch <- chromatogramHeader(x)
+    )
+    checkTrue(nrow(ch) == 0)
+    close(x)
+}
+

--- a/inst/unitTests/test_utils.R
+++ b/inst/unitTests/test_utils.R
@@ -1,0 +1,20 @@
+test_hasChromatograms <- function() {
+    fl <- system.file("proteomics/MRM-standmix-5.mzML.gz", package = "msdata")
+    x <- mzR::openMSfile(fl, backend = "pwiz")
+    checkTrue(mzR:::.hasChromatograms(x))
+    checkTrue(mzR:::.hasChromatograms(fl))
+    close(x)
+    
+    fl <- system.file("cdf/ko15.CDF", package = "msdata")
+    x <- openMSfile(fl, backend = "netCDF")        
+    suppressWarnings(checkTrue(!mzR:::.hasChromatograms(x)))
+    suppressWarnings(checkTrue(!mzR:::.hasChromatograms(fl)))
+    close(x)
+
+    fl <- system.file("sciex/20171016_POOL_POS_1_105-134.mzML",
+                      package = "msdata")
+    x <- mzR::openMSfile(fl, backend = "pwiz")
+    checkTrue(!mzR:::.hasChromatograms(x))
+    checkTrue(!mzR:::.hasChromatograms(fl))
+    close(x)
+}

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -29,6 +29,12 @@
 \alias{chromatogram,mzRpwiz-method}
 \alias{chromatogramHeader,mzRpwiz-method}
 \alias{chromatograms,mzRpwiz-method}
+\alias{chromatogram,mzRramp-method}
+\alias{chromatogramHeader,mzRramp-method}
+\alias{chromatograms,mzRramp-method}
+\alias{chromatogram,mzRnetCDF-method}
+\alias{chromatogramHeader,mzRnetCDF-method}
+\alias{chromatograms,mzRnetCDF-method}
 \alias{tic,mzRpwiz-method}
 \alias{nChrom}
 \alias{chromatogram}

--- a/src/RcppPwiz.cpp
+++ b/src/RcppPwiz.cpp
@@ -885,10 +885,11 @@ Rcpp::DataFrame RcppPwiz::getAllChromatogramHeaderInfo ( ) {
   if (msd != NULL) {
     ChromatogramListPtr clp = msd->run.chromatogramListPtr;
     int N = clp->size();
-    
-    return getChromatogramHeaderInfo(Rcpp::seq(1, N));
+    if (N > 0)
+      return getChromatogramHeaderInfo(Rcpp::seq(1, N));
+  } else {
+    Rprintf("Warning: pwiz not yet initialized.\n ");
   }
-  Rprintf("Warning: pwiz not yet initialized.\n ");
   return Rcpp::DataFrame::create( );
 }
 


### PR DESCRIPTION
- Add the .hasChromatograms function.
- Add chromatogram, chromatograms and chromatogramHeader methods for the ramp
  and netCDF backends.
- Add related unit tests.