### PR TITLE
Closing #181

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 CHANGES IN VERSION 2.15.5
 -------------------------
- o nothing yet
+ o Fix bug #188
 
 CHANGES IN VERSION 2.15.4
 -------------------------

--- a/R/methods-mzRident.R
+++ b/R/methods-mzRident.R
@@ -21,9 +21,8 @@ setMethod("specParams",
           signature = "mzRident",
           function(object) {
               pars <- object@backend$getSpecParams()
-              if ("scan.number.s." %in%  names(pars))
-                  if (!is.numeric(pars[, "scan.number.s."]))
-                      pars[, "scan.number.s."]  <- as.numeric(as.character(pars[, "scan.number.s."]))
+              if ("scan.number.s." %in%  names(pars) && !is.numeric(pars[, "scan.number.s."]))
+                  pars[, "scan.number.s."]  <- as.numeric(as.character(pars[, "scan.number.s."]))
               return(pars)
           })
 

--- a/R/methods-mzRident.R
+++ b/R/methods-mzRident.R
@@ -21,8 +21,9 @@ setMethod("specParams",
           signature = "mzRident",
           function(object) {
               pars <- object@backend$getSpecParams()
-              if ("scan.number.s." %in%  names(pars) & !is.numeric(pars[, "scan.number.s."]))
-                  pars[, "scan.number.s."]  <- as.numeric(as.character(pars[, "scan.number.s."]))
+              if ("scan.number.s." %in%  names(pars))
+                  if (!is.numeric(pars[, "scan.number.s."]))
+                      pars[, "scan.number.s."]  <- as.numeric(as.character(pars[, "scan.number.s."]))
               return(pars)
           })
 


### PR DESCRIPTION
Fixing #181. 
`"scan.number.s." %in%  names(pars) & !is.numeric(pars[, "scan.number.s."])`
evaluates both sides of `&`, triggering the error is `scan.number.s.` is not in the data frame.
Just learned from the manpage myself:
```
     ‘&’ and ‘&&’ indicate logical AND and ‘|’ and ‘||’ indicate
     logical OR.  The shorter form performs elementwise comparisons in
     much the same way as arithmetic operators.  The longer form
     evaluates left to right examining only the first element of each
     vector.  Evaluation proceeds only until the result is determined.
     The longer form is appropriate for programming control-flow and
     typically preferred in ‘if’ clauses.
...
Yours, Steffen