### PR TITLE
Add isolationWindowTargetMZ column to header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.17.2
+Version: 2.17.3
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Maintainer: Steffen Neumann <sneumann@ipb-halle.de>,
 	    Laurent Gatto <lg390@cam.ac.uk>,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+CHANGES IN VERSION 2.17.3
+-------------------------
+ o Extract isolation window from mzML files (issue #193): data.frame returned
+   by header gains columns "isolationWindowTargetMZ",
+   "isolationWindowLowerOffset", "isolationWindowUpperOffset".
+
 CHANGES IN VERSION 2.17.2
 -------------------------
  o Fix bug #185: Error in R_nc4_open: Too many open files

--- a/R/functions-utils.R
+++ b/R/functions-utils.R
@@ -37,10 +37,22 @@
                   mergedResultEndScanNum = "numeric",
                   injectionTime = "numeric",
                   filterString = "character",
-                  centroided = "logical"
+                  centroided = "logical",
+                  ionMobilityDriftTime = "numeric",
+                  isolationWindowTargetMZ = "numeric",
+                  isolationWindowLowerOffset = "numeric",
+                  isolationWindowUpperOffset = "numeric"
                   )
     if (!is.data.frame(x))
         return("'x' is supposed to be a data.frame")
+    if (!any(colnames(x) == "ionMobilityDriftTime"))
+        x$ionMobilityDriftTime <- NA_real_
+    if (!any(colnames(x) == "isolationWindowTargetMZ"))
+        x$isolationWindowTargetMZ <- NA_real_
+    if (!any(colnames(x) == "isolationWindowLowerOffset"))
+        x$isolationWindowLowerOffset <- NA_real_
+    if (!any(colnames(x) == "isolationWindowUpperOffset"))
+        x$isolationWindowUpperOffset <- NA_real_
     if (!(all(names(req_cols) %in% colnames(x))))
         return(paste0("'x' is missing one or more required columns: ",
                       paste(names(req_cols), collapse = ", ")))
@@ -48,12 +60,8 @@
     if (!any(colnames(x) == "spectrumId"))
         x$spectrumId <- paste0("scan=", x$acquisitionNum)
     x$spectrumId <- as.character(x$spectrumId)
-    ## Add ionMobilityDriftTime
-    if (!any(colnames(x) == "ionMobilityDriftTime"))
-        x$ionMobilityDriftTime <- NA_real_
     ## Hack in the spectrumId column.
-    req_cols <- c(req_cols, spectrumId = "character",
-                  ionMobilityDriftTime = "numeric")    
+    req_cols <- c(req_cols, spectrumId = "character")
     ## Subset and order the columns
     x <- x[, names(req_cols)]
     cn_x <- colnames(x)

--- a/R/methods-mzRnetCDF.R
+++ b/R/methods-mzRnetCDF.R
@@ -79,6 +79,9 @@ setMethod("header",
                             centroided = NA,
                             ionMobilityDriftTime = empty_val,
                             stringsAsFactors = FALSE)
+            result$isolationWindowTargetMZ <- NA_real_
+            result$isolationWindowLowerOffset <- NA_real_
+            result$isolationWindowUpperOffset <- NA_real_
             return(result)
           })
 

--- a/R/methods-mzRramp.R
+++ b/R/methods-mzRramp.R
@@ -48,6 +48,9 @@ setMethod("header",
               res$spectrumId <- paste0("scan=", res$acquisitionNum)
               res$centroided <- NA
               res$ionMobilityDriftTime <- NA_real_
+              res$isolationWindowTargetMZ <- NA_real_
+              res$isolationWindowLowerOffset <- NA_real_
+              res$isolationWindowUpperOffset <- NA_real_
               res
 })
 
@@ -65,6 +68,9 @@ setMethod("header",
               res$spectrumId <- paste0("scan=", res$acquisitionNum)
               res$centroided <- NA
               res$ionMobilityDriftTime <- NA_real_
+              res$isolationWindowTargetMZ <- NA_real_
+              res$isolationWindowLowerOffset <- NA_real_
+              res$isolationWindowUpperOffset <- NA_real_
               res
           })
 

--- a/inst/unitTests/test_cdf.R
+++ b/inst/unitTests/test_cdf.R
@@ -64,7 +64,7 @@ test_header <- function() {
   cdf <- openMSfile(file, backend="netCDF")        
 
   h <- header(cdf)
-  checkEquals(ncol(h), 23)
+  checkEquals(ncol(h), 26)
   checkEquals(nrow(h), 1278)
   checkTrue(any(colnames(h) == "centroided"))
   checkTrue(all(is.na(h$centroided)))
@@ -75,11 +75,11 @@ test_header <- function() {
   checkEquals(h$spectrumId, paste0("scan=", h$acquisitionNum))
   
   h <- header(cdf, 1)
-  checkEquals(ncol(h), 23)
+  checkEquals(ncol(h), 26)
   checkEquals(nrow(h), 1)
 
   h <- header(cdf, 2:3)
-  checkEquals(ncol(h), 23)
+  checkEquals(ncol(h), 26)
   checkEquals(nrow(h), 2)
 
   close(cdf)

--- a/inst/unitTests/test_pwiz.R
+++ b/inst/unitTests/test_pwiz.R
@@ -161,6 +161,9 @@ test_getScanHeaderInfo <- function() {
     scan_3$injectionTime <- 0
     scan_3$filterString <- NA_character_
     scan_3$centroided <- NA
+    scan_3$isolationWindowTargetMZ <- NA_real_
+    scan_3$isolationWindowLowerOffset <- NA_real_
+    scan_3$isolationWindowUpperOffset <- NA_real_
     checkEquals(scan_3[cn], scan_3_ramp[cn])
     
     ## Read all scan header
@@ -171,6 +174,9 @@ test_getScanHeaderInfo <- function() {
     all_scans$injectionTime <- 0
     all_scans$filterString <- NA_character_
     all_scans$centroided <- NA
+    all_scans$isolationWindowTargetMZ <- NA_real_
+    all_scans$isolationWindowLowerOffset <- NA_real_
+    all_scans$isolationWindowUpperOffset <- NA_real_
     checkEquals(all_scans[, cn], all_scans_ramp[, cn])
     
     ## passing the index of all scan headers should return the same
@@ -181,6 +187,9 @@ test_getScanHeaderInfo <- function() {
     all_scans_2$injectionTime <- 0
     all_scans_2$filterString <- NA_character_
     all_scans_2$centroided <- NA
+    all_scans_2$isolationWindowTargetMZ <- NA_real_
+    all_scans_2$isolationWindowLowerOffset <- NA_real_
+    all_scans_2$isolationWindowUpperOffset <- NA_real_
     checkEquals(all_scans[, cn], all_scans_2[, cn])
     checkEquals(as.list(all_scans[3, cn]), scan_3[cn])
     checkEquals(all_scans_2[, cn], all_scans_ramp_2[, cn])
@@ -193,6 +202,9 @@ test_getScanHeaderInfo <- function() {
     scan_3$injectionTime <- 0
     scan_3$filterString <- NA_character_
     scan_3$centroided <- NA
+    scan_3$isolationWindowTargetMZ <- NA_real_
+    scan_3$isolationWindowLowerOffset <- NA_real_
+    scan_3$isolationWindowUpperOffset <- NA_real_
     checkEquals(scan_3[, cn], scan_3_ramp[, cn])
 
     close(mzml)

--- a/inst/unitTests/test_write.R
+++ b/inst/unitTests/test_write.R
@@ -185,7 +185,8 @@ test_copyWriteMSData <- function() {
     rt_col <- colnames(hdr_mod) == "retentionTime"
     checkEquals(hdr_mod[, rt_col], hdr_new[, rt_col], tolerance = 0.01)
     cn <- colnames(hdr)[!(colnames(hdr) %in% c("injectionTime", "retentionTime",
-                                               "filterString", "spectrumId"))]
+                                               "filterString", "spectrumId",
+                                               "isolationWindowTargetMZ"))]
     checkEquals(hdr_mod[, cn], hdr_new[, cn])
     ## checkEquals(ii, ii_new)
 
@@ -243,7 +244,8 @@ test_copyWriteMSData <- function() {
     cn <- colnames(hdr_sub)[!(colnames(hdr_sub) %in% c("injectionTime",
                                                        "retentionTime",
                                                        "filterString",
-                                                       "spectrumId"))]
+                                                       "spectrumId",
+                                                       "isolationWindowTargetMZ"))]
     checkEquals(hdr_sub[, cn], hdr_new[, cn])    
     
     ## Other mzML:
@@ -441,7 +443,8 @@ test_writeMSData <- function() {
     cn <- colnames(hdr_mod)[!(colnames(hdr_mod) %in% c("retentionTime",
                                                        "injectionTime",
                                                        "filterString",
-                                                       "spectrumId"))]
+                                                       "spectrumId",
+                                                       "isolationWindowTargetMZ"))]
     checkEquals(hdr_mod[, cn], hdr_2[, cn])
     
     ## Subset. These checks ensure that the scan - precursor scan are mapped
@@ -508,7 +511,8 @@ test_writeMSData <- function() {
     cn <- colnames(hdr_sub)[!(colnames(hdr_sub) %in% c("injectionTime",
                                                        "retentionTime",
                                                        "filterString",
-                                                       "spectrumId"))]
+                                                       "spectrumId",
+                                                       "isolationWindowTargetMZ"))]
     checkEquals(hdr_sub[, cn], hdr_new[, cn])
     
     ## Other mzML:

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -122,8 +122,10 @@
   \code{filterString}, \code{spectrumId}, \code{centroided}
   (\code{logical} whether the data of the spectrum is in centroid mode
   or profile mode; only for pwiz backend), \code{injectionTime} (ion
-  injection time, in milliseconds) and \code{ionMobilityDriftTime} (in
-  milliseconds). If multiple scans are queried, a
+  injection time, in milliseconds), \code{ionMobilityDriftTime} (in
+  milliseconds), \code{isolationWindowTargetMZ},
+  \code{isolationWindowLowerOffset} and
+  \code{isolationWindowUpperOffset}. If multiple scans are queried, a
   \code{data.frame} is returned with the scans reported along the
   rows.
 


### PR DESCRIPTION
- Extract isolation window from mzML files (issue #193): data.frame returned by
  jeader gains columns "isolationWindowTargetMZ", "isolationWindowLowerOffset"
  and "isolationWindowUpperOffset" enabling SWATH data analysis.
- Adapt documentation and unit tests.