### PR TITLE
Fix issue introduced by changing quotes in Rhdf5lib::pkgconfig()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.19.6
+Version: 2.19.7
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Maintainer: Steffen Neumann <sneumann@ipb-halle.de>,
 	    Laurent Gatto <lg390@cam.ac.uk>,

--- a/src/Makevars
+++ b/src/Makevars
@@ -118,7 +118,7 @@ RHDF5_LIBS=$(shell echo 'Rhdf5lib::pkgconfig("PKG_CXX_LIBS")'| "${R_HOME}/bin/R"
 else
 ARCH_OBJS=./boost/libs/thread/src/pthread/once.o \
 ./boost/libs/thread/src/pthread/thread.o
-RHDF5_LIBS=`echo 'Rhdf5lib::pkgconfig("PKG_CXX_LIBS")'| "${R_HOME}/bin/R" --vanilla --slave`
+RHDF5_LIBS=$(shell echo 'Rhdf5lib::pkgconfig("PKG_CXX_LIBS")'| "${R_HOME}/bin/R" --vanilla --slave)
 endif
 
 MZROBJECTS=cramp.o ramp_base64.o ramp.o RcppRamp.o RcppRampModule.o RcppPwiz.o RcppPwizModule.o RcppIdent.o RcppIdentModule.o


### PR DESCRIPTION
Hi Steffan,

Apologies for breaking mzR so close to the release.  This patch should fix the issue in devel, and I've reverted the change in Rhdf5lib in RELEASE_3_9 so you shouldn't have to do anything to that either.

Sorry again!