### PR TITLE
fix: ensure header returns the same columns for all backends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.25.1
+Version: 2.25.2
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Maintainer: Steffen Neumann <sneumann@ipb-halle.de>,
 	    Laurent Gatto <laurent.gatto@uclouvain.be>,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 2.25.2
+-------------------------
+ o Fix issue #238: ensure `header` call returns the same columns for all
+   backends.
+
 CHANGES IN VERSION 2.25.1
 -------------------------
  o Bump version to trigger new build using latest Rcpp

--- a/R/methods-mzRnetCDF.R
+++ b/R/methods-mzRnetCDF.R
@@ -51,41 +51,44 @@ setMethod("header",
           signature=c("mzRnetCDF","missing"),
           function(object) return(header(object, 1:length(object))))
 
-setMethod("header",
-          signature=c("mzRnetCDF","numeric"),
-          function(object, scans) {
-            empty_val <- rep(-1, length(scans))
-            result <- data.frame(seqNum=scans,
-                            acquisitionNum=scans,
-                            msLevel=rep(1, length(scans)),
-                            peaksCount=rep(1, length(scans)),
-                            totIonCurrent=netCDFVarDouble(object@backend, "total_intensity")[scans],
-                            retentionTime=netCDFVarDouble(object@backend, "scan_acquisition_time")[scans], 
-                            basePeakMZ = empty_val,
-                            basePeakIntensity = empty_val,
-                            collisionEnergy = empty_val,
-                            ionisationEnergy = empty_val,
-                            highMZ = empty_val,
-                            precursorScanNum = empty_val,
-                            precursorMZ = empty_val,
-                            precursorCharge = empty_val,
-                            precursorIntensity = empty_val,
-                            mergedScan = empty_val,
-                            mergedResultScanNum = empty_val,
-                            mergedResultStartScanNum = empty_val,
-                            mergedResultEndScanNum = empty_val,
-                            injectionTime = empty_val,
-                            spectrumId = paste0("scan=", scans),
-                            centroided = NA,
-                            ionMobilityDriftTime = empty_val,
-                            stringsAsFactors = FALSE)
-            result$isolationWindowTargetMZ <- NA_real_
-            result$isolationWindowLowerOffset <- NA_real_
-            result$isolationWindowUpperOffset <- NA_real_
-            result$scanWindowLowerLimit <- NA_real_
-            result$scanWindowUpperLimit <- NA_real_
-            return(result)
-          })
+setMethod("header", c("mzRnetCDF", "numeric"), function(object, scans) {
+    ls <- length(scans)
+    empty_val <- rep(-1, ls)
+    na_real <- rep(NA_real_, ls)
+    result <- data.frame(
+        seqNum=scans,
+        acquisitionNum=scans,
+        msLevel=rep(1, length(scans)),
+        polarity = empty_val,
+        peaksCount=rep(1, length(scans)),
+        totIonCurrent=netCDFVarDouble(object@backend, "total_intensity")[scans],
+        retentionTime=netCDFVarDouble(object@backend, "scan_acquisition_time")[scans],
+        basePeakMZ = empty_val,
+        basePeakIntensity = empty_val,
+        collisionEnergy = empty_val,
+        ionisationEnergy = empty_val,
+        lowMZ = empty_val,
+        highMZ = empty_val,
+        precursorScanNum = empty_val,
+        precursorMZ = empty_val,
+        precursorCharge = empty_val,
+        precursorIntensity = empty_val,
+        mergedScan = empty_val,
+        mergedResultScanNum = empty_val,
+        mergedResultStartScanNum = empty_val,
+        mergedResultEndScanNum = empty_val,
+        injectionTime = empty_val,
+        filterString = NA_character_,
+        spectrumId = paste0("scan=", scans),
+        centroided = NA,
+        ionMobilityDriftTime = empty_val,
+        isolationWindowTargetMZ = na_real,
+        isolationWindowLowerOffset = na_real,
+        isolationWindowUpperOffset = na_real,
+        scanWindowLowerLimit = na_real,
+        scanWindowUpperLimit = na_real)
+    return(result)
+})
 
 setMethod("close", 
           signature="mzRnetCDF",

--- a/R/methods-mzRnetCDF.R
+++ b/R/methods-mzRnetCDF.R
@@ -58,8 +58,8 @@ setMethod("header", c("mzRnetCDF", "numeric"), function(object, scans) {
     result <- data.frame(
         seqNum=scans,
         acquisitionNum=scans,
-        msLevel=rep(1, length(scans)),
-        polarity = empty_val,
+        msLevel = rep(1L, length(scans)),
+        polarity = -1L,
         peaksCount=rep(1, length(scans)),
         totIonCurrent=netCDFVarDouble(object@backend, "total_intensity")[scans],
         retentionTime=netCDFVarDouble(object@backend, "scan_acquisition_time")[scans],

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,4 @@
-BUILT_RCPP_VERSION = package_version("0.12.19")
+BUILT_RCPP_VERSION = package_version("1.0.2")
 
 .onLoad <-
     function(libname, pkgname) {

--- a/inst/unitTests/test_cdf.R
+++ b/inst/unitTests/test_cdf.R
@@ -64,7 +64,7 @@ test_header <- function() {
   cdf <- openMSfile(file, backend="netCDF")        
 
   h <- header(cdf)
-  checkEquals(ncol(h), 28)
+  checkEquals(ncol(h), 31)
   checkEquals(nrow(h), 1278)
   checkTrue(any(colnames(h) == "centroided"))
   checkTrue(all(is.na(h$centroided)))
@@ -80,11 +80,11 @@ test_header <- function() {
   checkTrue(all(is.na(h$scanWindowUpperLimit)))
 
   h <- header(cdf, 1)
-  checkEquals(ncol(h), 28)
+  checkEquals(ncol(h), 31)
   checkEquals(nrow(h), 1)
 
   h <- header(cdf, 2:3)
-  checkEquals(ncol(h), 28)
+  checkEquals(ncol(h), 31)
   checkEquals(nrow(h), 2)
 
   close(cdf)

--- a/inst/unitTests/test_header.R
+++ b/inst/unitTests/test_header.R
@@ -1,0 +1,20 @@
+test_header_all <- function() {
+    ## Check that the header call returns the same columns irrespectively of the
+    ## backend. Issue #238
+    file <- system.file('cdf/ko15.CDF', package = "msdata")
+    cdf <- openMSfile(file, backend="netCDF")
+    header_cdf <- header(cdf)
+    close(cdf)
+
+    file <- system.file("threonine", "threonine_i2_e35_pH_tree.mzXML", package = "msdata")
+    mzxml <- openMSfile(file, backend="pwiz")
+    header_pwiz <- header(mzxml)
+    close(mzxml)
+
+    mzxml <- openMSfile(file, backend="Ramp")
+    header_ramp <- header(mzxml)
+    close(mzxml)
+
+    checkEquals(colnames(header_cdf), colnames(header_pwiz))
+    checkEquals(colnames(header_ramp), colnames(header_pwiz))
+}


### PR DESCRIPTION
- Fix for issue #238: ensure `header` returns the same columns for all backends.