### PR TITLE
Ensure header for CDF backend returns columns with correct data type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.25.2
+Version: 2.25.3
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Maintainer: Steffen Neumann <sneumann@ipb-halle.de>,
 	    Laurent Gatto <laurent.gatto@uclouvain.be>,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+CHANGES IN VERSION 2.25.3
+-------------------------
+ o Ensure `header` for CDF returns columns with correct data type.
+
 CHANGES IN VERSION 2.25.2
 -------------------------
  o Fix issue #238: ensure `header` call returns the same columns for all

--- a/R/methods-mzRnetCDF.R
+++ b/R/methods-mzRnetCDF.R
@@ -54,12 +54,13 @@ setMethod("header",
 setMethod("header", c("mzRnetCDF", "numeric"), function(object, scans) {
     ls <- length(scans)
     empty_val <- rep(-1, ls)
+    empty_int <- rep(-1L, ls)
     na_real <- rep(NA_real_, ls)
     result <- data.frame(
         seqNum=scans,
         acquisitionNum=scans,
         msLevel = rep(1L, length(scans)),
-        polarity = -1L,
+        polarity = empty_int,
         peaksCount=rep(1, length(scans)),
         totIonCurrent=netCDFVarDouble(object@backend, "total_intensity")[scans],
         retentionTime=netCDFVarDouble(object@backend, "scan_acquisition_time")[scans],
@@ -69,9 +70,9 @@ setMethod("header", c("mzRnetCDF", "numeric"), function(object, scans) {
         ionisationEnergy = empty_val,
         lowMZ = empty_val,
         highMZ = empty_val,
-        precursorScanNum = empty_val,
+        precursorScanNum = empty_int,
         precursorMZ = empty_val,
-        precursorCharge = empty_val,
+        precursorCharge = empty_int,
         precursorIntensity = empty_val,
         mergedScan = empty_val,
         mergedResultScanNum = empty_val,

--- a/R/methods-mzRnetCDF.R
+++ b/R/methods-mzRnetCDF.R
@@ -61,7 +61,7 @@ setMethod("header", c("mzRnetCDF", "numeric"), function(object, scans) {
         acquisitionNum=scans,
         msLevel = rep(1L, length(scans)),
         polarity = empty_int,
-        peaksCount=rep(1, length(scans)),
+        peaksCount=rep(1L, length(scans)),
         totIonCurrent=netCDFVarDouble(object@backend, "total_intensity")[scans],
         retentionTime=netCDFVarDouble(object@backend, "scan_acquisition_time")[scans],
         basePeakMZ = empty_val,


### PR DESCRIPTION
Ensure the `header` method for the netCDF backend returns columns in correct data type.