### PR TITLE
refactor: patially rewrite code to exctract header info

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML, mzData and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.27.2
+Version: 2.27.3
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Maintainer: Steffen Neumann <sneumann@ipb-halle.de>,
             Laurent Gatto <laurent.gatto@uclouvain.be>,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 2.27.3
+-------------------------
+ o Pwiz backend partially re-written to avoid segfault on macOS
+   (https://github.com/sneumann/xcms/issues/422).
+
 CHANGES IN VERSION 2.27.2
 -------------------------
  o Remove support for the ramp backend.

--- a/R/methods-mzRpwiz.R
+++ b/R/methods-mzRpwiz.R
@@ -50,10 +50,12 @@ setMethod("detector", "mzRpwiz",
 
 setMethod("header", c("mzRpwiz", "missing"),
           function(object) {
-              res <- object@backend$getAllScanHeaderInfo()
-              res$filterString <- as.character(res$filterString)
-              res$spectrumId <- as.character(res$spectrumId)
-              res
+              scans <- seq_len(object@backend$getLastScan())
+              ## res <- object@backend$getAllScanHeaderInfo()
+              ## res$filterString <- as.character(res$filterString)
+              ## res$spectrumId <- as.character(res$spectrumId)
+              ## res
+              header(object, scans)
           })
 
 setMethod("header", c("mzRpwiz", "numeric"),

--- a/src/RcppPwiz.cpp
+++ b/src/RcppPwiz.cpp
@@ -3,6 +3,7 @@
 RcppPwiz::RcppPwiz()
 {
   msd = NULL;
+  nativeIdFormat = CVID_Unknown;
   instrumentInfo = Rcpp::List::create();
   chromatogramsInfo = Rcpp::DataFrame::create();
   isInCacheInstrumentInfo = FALSE;
@@ -15,12 +16,15 @@ RcppPwiz::~RcppPwiz()
   RcppPwiz::close();
 }
 
-void RcppPwiz::open(const string& fileName)
+// void RcppPwiz::open(const string& fileName)
+void RcppPwiz::open(Rcpp::StringVector fileName)
 {
 
-  filename = fileName;
-  msd = new MSDataFile(fileName);
-
+  filename = Rcpp::as<std::string>(fileName(0));
+  msd = new MSDataFile(filename);
+  // Better not to guess the native ID format. For mzML/mzXML all should be fine
+  // with the default one.
+  // nativeIdFormat = id::getDefaultNativeIDFormat(*msd);
 }
 
 /* Release all memory on close. */
@@ -30,6 +34,7 @@ void RcppPwiz::close()
     {
       delete msd;
       msd = NULL;
+      nativeIdFormat = CVID_Unknown;
       instrumentInfo = Rcpp::List::create();
       chromatogramsInfo = Rcpp::DataFrame::create();
       isInCacheInstrumentInfo = FALSE;
@@ -127,12 +132,47 @@ Rcpp::List RcppPwiz::getInstrumentInfo ( )
   return instrumentInfo;
 }
 
+// int RcppPwiz::getAcquisitionNumber(size_t index) const
+// {
+//   const SpectrumIdentity& si = msd->run.spectrumListPtr->spectrumIdentity(index);
+//   string scanNumber = id::translateNativeIDToScanNumber(nativeIdFormat, si.id);
+//   if (scanNumber.empty()) {
+//     return static_cast<int>(index) + 1;
+//   }
+//   else
+//     return lexical_cast<int>(scanNumber);
+//   // return static_cast<int>(index) + 1;
+// }
+
+// Using this function instead of pwiz translateNativeIDToScanNumber because
+// it randomly causes segfaults on macOS.
+int RcppPwiz::getAcquisitionNumber(string id, size_t index) const
+{
+  if (id.find("controllerType") != std::string::npos) {
+    if (id.find("controllerType=0 controllerNumber=1") == std::string::npos)
+      return static_cast<int>(index) + 1;
+  }
+  string e;
+  std::smatch match;
+  if (id.find("scan=") != std::string::npos)
+    e ="scan=(\\d+)";
+  else if (id.find("index=") != std::string::npos)
+    e = "index=(\\d+)";
+  else if (id.find("spectrum=") != std::string::npos)
+    e = "spectrum=(\\d+)";
+  else if (id.find("scanId=") != std::string::npos)
+    e = "scanId=(\\d+)";
+  else return static_cast<int>(index) + 1;
+  if (std::regex_search(id, match, std::regex(e)))
+    return lexical_cast<int>(match[1]);
+  else return static_cast<int>(index) + 1;
+}
+
 Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan) {
   if (msd != NULL) {
     SpectrumListPtr slp = msd->run.spectrumListPtr;
-    int N = slp->size();
-    int N_scans = whichScan.size();
-    CVID nativeIdFormat = id::getDefaultNativeIDFormat(*msd);
+    size_t N = slp->size();
+    size_t N_scans = whichScan.size();
     Rcpp::IntegerVector seqNum(N_scans); // number in sequence observed file (1-based)
     Rcpp::IntegerVector acquisitionNum(N_scans); // scan number as declared in File (may be gaps)
     Rcpp::IntegerVector msLevel(N_scans);
@@ -165,23 +205,20 @@ Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan) {
     Rcpp::NumericVector scanWindowLowerLimit(N_scans);
     Rcpp::NumericVector scanWindowUpperLimit(N_scans);
     
-    for (int i = 0; i < N_scans; i++) {
+    for (size_t i = 0; i < N_scans; i++) {
       int current_scan = whichScan[i];
-      SpectrumPtr sp = slp->spectrum(current_scan - 1, false);
+      size_t current_index = static_cast<size_t>(current_scan - 1);
+      // SpectrumPtr sp = slp->spectrum(current_index, false);
+      SpectrumPtr sp = slp->spectrum(current_index, DetailLevel_FullMetadata);
       Scan dummy;
       Scan& scan = sp->scanList.scans.empty() ? dummy : sp->scanList.scans[0];
+      if (scan.empty())
+	Rprintf("Scan with index %d empty.\n", current_scan);
       // seqNum
       seqNum[i] = current_scan;
-      // acquisitionNum
-      string id = sp->id;
-      string scanNumber = id::translateNativeIDToScanNumber(nativeIdFormat, id);
-      if (scanNumber.empty()) {
-	acquisitionNum[i] = current_scan;
-      } else {
-	acquisitionNum[i] = lexical_cast<int>(scanNumber);
-      }
+      acquisitionNum[i] = getAcquisitionNumber(sp->id, current_index);
       // spectrumId
-      spectrumId[i] = sp->id;
+      spectrumId[i] = Rcpp::String(sp->id);
       // msLevel
       msLevel[i] = sp->cvParam(MS_ms_level).valueAs<int>();
       // peaksCount
@@ -231,14 +268,8 @@ Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan) {
 	collisionEnergy[i] = precursor.activation.cvParam(MS_collision_energy).valueAs<double>();
 	// precursorScanNum
 	size_t precursorIndex = slp->find(precursor.spectrumID);
-	if (precursorIndex < slp->size()) {
-	  const SpectrumIdentity& precursorSpectrum = slp->spectrumIdentity(precursorIndex);
-	  string precursorScanNumber = id::translateNativeIDToScanNumber(nativeIdFormat, precursorSpectrum.id);
-	  if (precursorScanNumber.empty()) {
-	    precursorScanNum[i] = precursorIndex + 1;
-	  } else {
-	    precursorScanNum[i] = lexical_cast<int>(precursorScanNumber);
-	  }
+	if (precursorIndex < N) {
+	  precursorScanNum[i] = getAcquisitionNumber(precursor.spectrumID, precursorIndex);
 	} else {
 	  precursorScanNum[i] = NA_INTEGER;
 	}
@@ -277,7 +308,7 @@ Rcpp::DataFrame RcppPwiz::getScanHeaderInfo (Rcpp::IntegerVector whichScan) {
     
     Rcpp::List header(31);
     std::vector<std::string> names;
-    int i = 0;
+    size_t i = 0;
     names.push_back("seqNum");
     header[i++] = Rcpp::wrap(seqNum);
     names.push_back("acquisitionNum");
@@ -352,7 +383,7 @@ Rcpp::DataFrame RcppPwiz::getAllScanHeaderInfo ( ) {
   if (msd != NULL) {
     if (!isInCacheAllScanHeaderInfo) {
       SpectrumListPtr slp = msd->run.spectrumListPtr;
-      int N = slp->size();
+      size_t N = slp->size();
       
       allScanHeaderInfo = getScanHeaderInfo(Rcpp::seq(1, N));
       isInCacheAllScanHeaderInfo = TRUE;	    
@@ -366,21 +397,23 @@ Rcpp::DataFrame RcppPwiz::getAllScanHeaderInfo ( ) {
 Rcpp::List RcppPwiz::getPeakList(Rcpp::IntegerVector whichScan) {
   if (msd != NULL) {
     SpectrumListPtr slp = msd->run.spectrumListPtr;
-    int n_scans = slp->size();
-    int n_want = whichScan.size();
+    size_t n_scans = slp->size();
+    size_t n_want = whichScan.size();
     int current_scan;
     SpectrumPtr sp;
     BinaryDataArrayPtr mzs,ints;
     std::vector<double> data;
     Rcpp::NumericVector data_matrix;
     Rcpp::List res(n_want);
-    for (int i = 0; i < n_want; i++) {
+    for (size_t i = 0; i < n_want; i++) {
       current_scan = whichScan[i];
       if (current_scan < 1 || current_scan > n_scans) {
 	Rprintf("Index whichScan out of bounds [1 ... %d].\n", n_scans);
 	return Rcpp::List::create( );
       }
-      sp = slp->spectrum(current_scan - 1, true);
+      size_t current_index = static_cast<size_t>(current_scan - 1);
+      // sp = slp->spectrum(current_index, true);
+      sp = slp->spectrum(current_index, DetailLevel_FullData);
       mzs = sp->getMZArray();
       ints = sp->getIntensityArray();
       if (!mzs.get() || !ints.get()) {
@@ -847,7 +880,7 @@ Rcpp::DataFrame RcppPwiz::getChromatogramsInfo( int whichChrom )
 Rcpp::DataFrame RcppPwiz::getChromatogramHeaderInfo (Rcpp::IntegerVector whichChrom)
 {
   if (msd != NULL) {
-    CVID nativeIdFormat_ = id::getDefaultNativeIDFormat(*msd);
+    // CVID nativeIdFormat_ = id::getDefaultNativeIDFormat(*msd);
     ChromatogramListPtr clp = msd->run.chromatogramListPtr;
     if (clp.get() == 0) {
       Rf_warningcall(R_NilValue, "The direct support for chromatogram info is only available in mzML format.");
@@ -980,7 +1013,7 @@ Rcpp::NumericMatrix RcppPwiz::get3DMap ( std::vector<int> scanNumbers, double wh
       //Rprintf("%d\n",1);
       for (int i = 0; i < scanNumbers.size(); i++)
         {
-	  SpectrumPtr s = slp->spectrum(scanNumbers[i] - 1, true);
+	  SpectrumPtr s = slp->spectrum(scanNumbers[i] - 1, DetailLevel_FullMetadata);
 	  vector<MZIntensityPair> pairs;
 	  s->getMZIntensityPairs(pairs);
 

--- a/src/RcppPwiz.h
+++ b/src/RcppPwiz.h
@@ -28,6 +28,7 @@
 #include <fstream>
 #include <string>
 #include <iostream>
+#include <regex>
 
 #if defined(__MINGW32__)
 #include <windows.h>
@@ -49,18 +50,21 @@ private:
     Rcpp::DataFrame allScanHeaderInfo;
     bool isInCacheAllScanHeaderInfo;
     string filename;
+    CVID nativeIdFormat;
     void addSpectrumList(MSData& msd,
 			 Rcpp::DataFrame& spctr_header,
 			 Rcpp::List& spctr_data,
 			 bool rtime_seconds);
     void addDataProcessing(MSData& msd, Rcpp::StringVector soft_proc);
-
+    int getAcquisitionNumber(string id, size_t index) const;
+  
 public:
 
     RcppPwiz();
     virtual ~RcppPwiz();
 
-    void open(const string& fileNames);
+    // void open(const string& fileNames);
+    void open(Rcpp::StringVector fileNames);
     void close();
     /* void writeMSfile(const string& filenames, const string& format); */
     void writeSpectrumList(const string& file, const string& format,


### PR DESCRIPTION
- Create index list in R instead of C++.
- Use `size_t` instead of `int` where suitable.
- Ensure that correct data types are passed between R and C++.
- Use new (own) implementation to extract the acquisition number from the
  spectrum ID instead of `id::translateNativeIDToScanNumber` from proteowizard
  to avoid segfaults on macOS (https://github.com/sneumann/xcms/issues/422).