### PR TITLE
refactor: header always returns a `data.frame` (PR #253)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ CHANGES IN VERSION 2.29.2
 -------------------------
  o Update to Proteowizard 3_0_21263
  o Removed RAMP backend, dropping ability to read mzData
+ o header always returns a data.frame even for a single scan.
 
 CHANGES IN VERSION 2.29.1
 -------------------------

--- a/R/methods-mzRpwiz.R
+++ b/R/methods-mzRpwiz.R
@@ -51,10 +51,6 @@ setMethod("detector", "mzRpwiz",
 setMethod("header", c("mzRpwiz", "missing"),
           function(object) {
               scans <- seq_len(object@backend$getLastScan())
-              ## res <- object@backend$getAllScanHeaderInfo()
-              ## res$filterString <- as.character(res$filterString)
-              ## res$spectrumId <- as.character(res$spectrumId)
-              ## res
               header(object, scans)
           })
 
@@ -63,10 +59,6 @@ setMethod("header", c("mzRpwiz", "numeric"),
               res <- object@backend$getScanHeaderInfo(scans)
               res$filterString <- as.character(res$filterString)
               res$spectrumId <- as.character(res$spectrumId)
-              if (length(scans) == 1) {
-                  ## Convert data.frame to list to be conform with old code
-                  res <- as.list(res)
-              }
               res
           })
 

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -98,7 +98,7 @@
   provided (i.e all spectra in the oject are retured). \code{peaksCount}
   will return a numeric of length \code{n}.
   
-  The \code{\link{header}} function returns a list containing
+  The \code{\link{header}} function returns a \code{data.frame} containing
   \code{seqNum}, \code{acquisitionNum}, \code{msLevel},
   \code{peaksCount}, \code{totIonCurrent}, \code{retentionTime} (in
   seconds), \code{basePeakMZ}, \code{basePeakIntensity},


### PR DESCRIPTION
- Fix header for pwiz backend to always return a `data.frame`.
- Update documentation.