### PR TITLE
refactor: change colnames of chromatogram() data.frame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.41.1
+Version: 2.41.2
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Authors@R: c(
     person("Steffen", "Neumann", email="sneumann@ipb-halle.de", role=c("aut","cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 2.41.2
+-------------------------
+o Use "rtime" and "intensity" as column names for the data.frame returned by
+  chromatogram() (# 304).
+
 CHANGES IN VERSION 2.41.1
 -------------------------
 o Fix compilation error with stricter compiler checks

--- a/R/methods-mzRpwiz.R
+++ b/R/methods-mzRpwiz.R
@@ -158,31 +158,25 @@ setMethod("chromatograms", "mzRpwiz",
 
 
 setMethod("chromatogram", "mzRpwiz",
-          function(object, chrom) {
+          function(object, chrom, drop = TRUE) {
               ## To avoid confusion, the first chromatogram (at index
               ## 0) is indexed at position 1 in R and the last one (at
               ## index nChrom(object) - 1) is indexed at position
               ## nChrom(object).
               n <- nChrom(object)
               all <- FALSE
-              if (missing(chrom)) {
+              if (missing(chrom))
                   chrom <- 1:n
-                  all <- TRUE
-              }
               stopifnot(is.numeric(chrom))
               chrom <- as.integer(chrom)
               if (min(chrom) < 1 | max(chrom) > n)
                   stop("Index out of bound [", 1, ":", n, "].")
               ## Update index to match original indices at the C-level
               chrom <- chrom - 1L
-              if (length(chrom) == 1 & !all) {
-                  ans <- object@backend$getChromatogramsInfo(chrom)
-              } else {
-                  ans <- lapply(chrom,
-                                function(x)
-                                    object@backend$getChromatogramsInfo(x))
-              }
-              return(ans)
+              if (length(chrom) == 1 && drop)
+                  object@backend$getChromatogramsInfo(chrom)
+              else
+                  lapply(chrom, object@backend$getChromatogramsInfo)
           })
 
 setMethod("chromatogramHeader", "mzRpwiz",

--- a/inst/unitTests/test_chromatograms.R
+++ b/inst/unitTests/test_chromatograms.R
@@ -12,7 +12,11 @@ test_chromatograms1 <- function() {
     checkIdentical(nrow(chromatogram(x, 137L)), 567L)
     checkIdentical(nrow(chromatogram(x, 138L)), 567L)
     chr <- chromatogram(x, 138L)
+    checkTrue(is.data.frame(chr))
     checkIdentical(colnames(chr), c("rtime", "intensity"))
+    chrl <- chromatogram(x, 138L, drop = FALSE)
+    checkTrue(is.list(chrl))
+    checkEquals(chr, chrl[[1L]])
 }
 
 test_chromatograms2 <- function() {

--- a/inst/unitTests/test_chromatograms.R
+++ b/inst/unitTests/test_chromatograms.R
@@ -11,6 +11,8 @@ test_chromatograms1 <- function() {
     checkIdentical(nrow(chromatogram(x, 136L)), 527L)
     checkIdentical(nrow(chromatogram(x, 137L)), 567L)
     checkIdentical(nrow(chromatogram(x, 138L)), 567L)
+    chr <- chromatogram(x, 138L)
+    checkIdentical(colnames(chr), c("rtime", "intensity"))
 }
 
 test_chromatograms2 <- function() {

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -84,6 +84,14 @@
     for all chromatograms is returned. 
   }
   
+  \item{drop}{
+    For \code{chromatogram}, \code{chromatograms}: \code{logical(1)}
+    whether the result should always be a \code{list} of
+    \code{data.frame} (\code{drop = FALSE}), even if data from a single
+    chromatogram is requested, or if, in such cases, a \code{data.frame}
+    should be returned (\code{drop = TRUE}, the default).    
+  }
+  
   \item{...}{Other arguments. A \code{scan} parameter can be passed to
     \code{peaks}.}  }
 

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -125,9 +125,8 @@
 
   The \code{chromatogram} (\code{chromatograms}) accessors return
   chromatograms for the MS file handle. If a single index is provided,
-  as \code{data.frame} containing the retention time (1st columns) and
-  intensities (2nd column) is returned. The name of the former is always
-  \code{time}, while the latter will depend on the run parameters.
+  as \code{data.frame} containing the retention time (\code{"rtime"},
+  1st column) and intensities (\code{"intensity"}, 2nd column) is returned.
 
   If more than 1 or no chromatogram indices are provided, then a list of
   chromatograms is returned; either those passed as argument or all of

--- a/src/RcppPwiz.cpp
+++ b/src/RcppPwiz.cpp
@@ -866,8 +866,8 @@ Rcpp::DataFrame RcppPwiz::getChromatogramsInfo( int whichChrom )
 	intensity.push_back(p.intensity);
       }
 
-      chromatogramsInfo = Rcpp::DataFrame::create(Rcpp::_["time"] = time,
-						  Rcpp::_[c->id]  = intensity);
+      chromatogramsInfo = Rcpp::DataFrame::create(Rcpp::_["rtime"] = time,
+						  Rcpp::_["intensity"] = intensity);
 
     }
     return(chromatogramsInfo);


### PR DESCRIPTION
- Change the column names of the `data.frame` returned by `chromatogram()` to `"rtime"` and `"intensity"` (issue #304).