### PR TITLE
Fix column names of data returned by chromatogram() to "rtime" and "intensity"

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^\.Rproj\.user$
 ^\.gitignore$
 ^\.git$
+^\.github$

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -127,7 +127,7 @@ jobs:
           ## https://mac.r-project.org/bin/darwin17/x86_64/
           ## The path might need to be updated depending on the macOS version.
           curl -O https://mac.r-project.org/bin/darwin17/x86_64/openssl-3.3.2-darwin.17-x86_64.tar.xz
-          tar fvxm openssl-3.3.2-darwin.17-x86_64.tar.xz -C /
+          tar -xvmpf openssl-3.3.2-darwin.17-x86_64.tar.xz -C /
           rm openssl-3.3.2-darwin.17-x86_64.tar.xz
           
       - name: Install Windows system dependencies

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -126,9 +126,10 @@ jobs:
           ## Install pre-compiled libraries from
           ## https://mac.r-project.org/bin/darwin17/x86_64/
           ## The path might need to be updated depending on the macOS version.
-          curl -O https://mac.r-project.org/bin/darwin17/x86_64/openssl-3.3.2-darwin.17-x86_64.tar.xz
-          tar -xvmpf openssl-3.3.2-darwin.17-x86_64.tar.xz -C /
-          rm openssl-3.3.2-darwin.17-x86_64.tar.xz
+          
+          curl -O https://mac.r-project.org/bin/darwin20/arm64/openssl-3.3.2-darwin.20-arm64.tar.xz
+          tar -xvmpf openssl-3.3.2-darwin.20-arm64.tar.xz -C /
+          rm openssl-3.3.2-darwin.20-arm64.tar.xz
           
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -127,9 +127,9 @@ jobs:
           ## https://mac.r-project.org/bin/darwin17/x86_64/
           ## The path might need to be updated depending on the macOS version.
           
-          curl -O https://mac.r-project.org/bin/darwin20/arm64/openssl-3.3.2-darwin.20-arm64.tar.xz
-          tar -xvmpf openssl-3.3.2-darwin.20-arm64.tar.xz -C /
-          rm openssl-3.3.2-darwin.20-arm64.tar.xz
+          # curl -O https://mac.r-project.org/bin/darwin20/arm64/openssl-3.3.2-darwin.20-arm64.tar.xz
+          # tar -xvmpf openssl-3.3.2-darwin.20-arm64.tar.xz -C /
+          # rm openssl-3.3.2-darwin.20-arm64.tar.xz
           
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -123,8 +123,13 @@ jobs:
       - name: Install macOS system dependencies
         if: matrix.config.os == 'macOS-latest'
         run: |
-          brew install openssl
-
+          ## Install pre-compiled libraries from
+          ## https://mac.r-project.org/bin/darwin17/x86_64/
+          ## The path might need to be updated depending on the macOS version.
+          curl -O https://mac.r-project.org/bin/darwin17/x86_64/openssl-3.3.2-darwin.17-x86_64.tar.xz
+          tar fvxm openssl-3.3.2-darwin.17-x86_64.tar.xz -C /
+          rm openssl-3.3.2-darwin.17-x86_64.tar.xz
+          
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'
         run: |
@@ -176,7 +181,7 @@ jobs:
         if:  env.has_RUnit == 'true'
         run: |
           ## Install BiocGenerics
-          BiocManager::install("BiocGenerics")
+          BiocManager::install(c("BiocGenerics", "RUnit"))
         shell: Rscript {0}
 
       - name: Install covr

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Install macOS system dependencies
         if: matrix.config.os == 'macOS-latest'
         run: |
-        shell: Rscript {0}
+          brew install openssl
 
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -34,10 +34,10 @@ name: R-CMD-check-bioc
 ## Note that you can always run a GHA test without the cache by using the word
 ## "/nocache" in the commit message.
 env:
-  has_testthat: 'true'
+  has_testthat: 'false'
   run_covr: 'true'
   run_pkgdown: 'true'
-  has_RUnit: 'false'
+  has_RUnit: 'true'
   has_BiocCheck: 'false'
   cache-version: 'cache-v1'
 
@@ -123,32 +123,7 @@ jobs:
       - name: Install macOS system dependencies
         if: matrix.config.os == 'macOS-latest'
         run: |
-          ## Enable installing XML from source if needed
-          brew install libxml2
-          echo "XML_CONFIG=/usr/local/opt/libxml2/bin/xml2-config" >> $GITHUB_ENV
-
-          ## Required to install magick as noted at
-          ## https://github.com/r-lib/usethis/commit/f1f1e0d10c1ebc75fd4c18fa7e2de4551fd9978f#diff-9bfee71065492f63457918efcd912cf2
-          brew install imagemagick@6
-
-          ## For textshaping, required by ragg, and required by pkgdown
-          brew install harfbuzz fribidi
-
-          ## For installing usethis's dependency gert
-          brew install libgit2
-
-          ## required for ncdf4
-          ## brew install netcdf ## Does not work as it is compiled with gcc
-          ## Use pre-compiled libraries from https://mac.r-project.org/libs-4/
-          curl -O https://mac.r-project.org/libs-4/netcdf-4.7.4-darwin.17-x86_64.tar.gz
-          tar fvxzm netcdf-4.7.4-darwin.17-x86_64.tar.gz -C /
-          rm netcdf-4.7.4-darwin.17-x86_64.tar.gz
-          curl -O https://mac.r-project.org/libs-4/hdf5-1.12.0-darwin.17-x86_64.tar.gz
-          tar fvxzm hdf5-1.12.0-darwin.17-x86_64.tar.gz -C /
-          rm hdf5-1.12.0-darwin.17-x86_64.tar.gz
-          curl -O https://mac.r-project.org/libs-4/szip-2.1.1-darwin.17-x86_64.tar.gz
-          tar fvxzm szip-2.1.1-darwin.17-x86_64.tar.gz -C /
-          rm szip-2.1.1-darwin.17-x86_64.tar.gz
+        shell: Rscript {0}
 
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'
@@ -205,13 +180,13 @@ jobs:
         shell: Rscript {0}
 
       - name: Install covr
-        if: github.ref == 'refs/heads/master' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/devel' && env.run_covr == 'true' && runner.os == 'Linux'
         run: |
           remotes::install_cran("covr")
         shell: Rscript {0}
 
       - name: Install pkgdown
-        if: github.ref == 'refs/heads/master' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
           remotes::install_github("r-lib/pkgdown")
         shell: Rscript {0}
@@ -261,20 +236,21 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        if: github.ref == 'refs/heads/master' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/devel' && env.run_covr == 'true' && runner.os == 'Linux'
         run: |
           covr::codecov()
         shell: Rscript {0}
 
       - name: Install package
-        if: github.ref == 'refs/heads/master' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: R CMD INSTALL .
 
       - name: Deploy package
-        if: github.ref == 'refs/heads/master' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
+          git config --global --add safe.directory /__w/mzR/mzR
           Rscript -e "pkgdown::deploy_to_branch(new_process = FALSE)"
         shell: bash {0}
         ## Note that you need to run pkgdown::deploy_to_branch(new_process = FALSE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.41.3
+Version: 2.41.4
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Authors@R: c(
     person("Steffen", "Neumann", email="sneumann@ipb-halle.de", role=c("aut","cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
+CHANGES IN VERSION 2.41.4
+-------------------------
+o Use "rtime" and "intensity" as column names for the data.frame returned
+  by `chromatogram()`. Fixes #304.
+
 CHANGES IN VERSION 2.41.3
 -------------------------
-o Fixed off-by-one indexing issue with index access for chromatogramHeader vs chromatogram. Fixes #302. Thanks Nils Hoffmann !
+o Fixed off-by-one indexing issue with index access for chromatogramHeader vs
+  chromatogram. Fixes #302. Thanks Nils Hoffmann !
 
 CHANGES IN VERSION 2.41.2
 -------------------------

--- a/R/methods-mzRpwiz.R
+++ b/R/methods-mzRpwiz.R
@@ -154,34 +154,29 @@ setMethod("tic", "mzRpwiz",
           })
 
 setMethod("chromatograms", "mzRpwiz",
-          function(object, chrom) chromatogram(object, chrom))
-
+          function(object, chrom, drop = TRUE) chromatogram(object, chrom,
+                                                            drop = drop))
 
 setMethod("chromatogram", "mzRpwiz",
-          function(object, chrom) {
+          function(object, chrom, drop = TRUE) {
               ## To avoid confusion, the first chromatogram (at index
               ## 0) is indexed at position 1 in R and the last one (at
               ## index nChrom(object) - 1) is indexed at position
               ## nChrom(object).
               n <- nChrom(object)
-              all <- FALSE
-              if (missing(chrom)) {
+              if (missing(chrom))
                   chrom <- 1:n
-                  all <- TRUE
+              else {
+                  stopifnot(is.numeric(chrom))
+                  chrom <- as.integer(chrom)
               }
-              stopifnot(is.numeric(chrom))
-              chrom <- as.integer(chrom)
               if (min(chrom) < 1 | max(chrom) > n)
                   stop("Index out of bound [", 1, ":", n, "].")
               # chromatogram index is adjusted in the backend function
-              if (length(chrom) == 1 & !all) {
-                  ans <- object@backend$getChromatogramsInfo(chrom)
-              } else {
-                  ans <- lapply(chrom,
-                                function(x)
-                                    object@backend$getChromatogramsInfo(x))
-              }
-              return(ans)
+              if (drop && length(chrom) == 1)
+                  object@backend$getChromatogramsInfo(chrom)
+              else
+                  lapply(chrom, object@backend$getChromatogramsInfo)
           })
 
 setMethod("chromatogramHeader", "mzRpwiz",
@@ -191,7 +186,6 @@ setMethod("chromatogramHeader", "mzRpwiz",
               } else {
                   stopifnot(is.numeric(chrom))
                   n <- nChrom(object)
-
                   if (min(chrom) < 1 | max(chrom) > n)
                     stop("Index out of bound [", 1, ":", n, "]")
                   # chromatogram index is adjusted in the backend function

--- a/inst/unitTests/test_chromatograms.R
+++ b/inst/unitTests/test_chromatograms.R
@@ -11,6 +11,12 @@ test_chromatograms1 <- function() {
     checkIdentical(nrow(chromatogram(x, 136L)), 527L)
     checkIdentical(nrow(chromatogram(x, 137L)), 567L)
     checkIdentical(nrow(chromatogram(x, 138L)), 567L)
+    chr <- chromatogram(x, 138L)
+    checkTrue(is.data.frame(chr))
+    checkIdentical(colnames(chr), c("rtime", "intensity"))
+    chr1 <- chromatogram(x, 138L, drop = FALSE)
+    checkTrue(is.list(chr1))
+    checkEquals(chr, chr1[[1L]])
     close(x)
 }
 
@@ -62,9 +68,9 @@ test_chromatogramHeader_indexing <- function() {
         checkTrue(grepl("Index out of bound", e$message))
     })
 
+    all_chrom <- chromatogram(x)
     chrom2 <- chromatogram(x, 2)
-    ch2SafeChromId <- make.names(ch2$chromatogramId)
-    checkEquals(ch2SafeChromId, colnames(chrom2)[2])
+    checkEquals(all_chrom[[2]], chrom2)
 
     close(x)
 }

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -84,6 +84,14 @@
     for all chromatograms is returned. 
   }
   
+  \item{drop}{
+    For \code{chromatogram()}, \code{chromatograms()}: \code{logical(1)}
+    whether the result should always be a \code{list} of
+    \code{data.frame} (\code{drop = FALSE}), even if data from a single
+    chromatogram is requested, or if, in such cases, a \code{data.frame}
+    should be returned (\code{drop = TRUE}, the default).    
+  }
+  
   \item{...}{Other arguments. A \code{scan} parameter can be passed to
     \code{peaks}.}  }
 
@@ -125,9 +133,9 @@
 
   The \code{chromatogram} (\code{chromatograms}) accessors return
   chromatograms for the MS file handle. If a single index is provided,
-  as \code{data.frame} containing the retention time (1st columns) and
-  intensities (2nd column) is returned. The name of the former is always
-  \code{time}, while the latter will depend on the run parameters.
+  as \code{data.frame} containing the retention time (\code{"rtime"},
+  first column) and intensities (\code{"intensity"}, second column) is
+  returned.
 
   If more than 1 or no chromatogram indices are provided, then a list of
   chromatograms is returned; either those passed as argument or all of

--- a/man/peaks.Rd
+++ b/man/peaks.Rd
@@ -51,9 +51,9 @@
 
  get3Dmap(object, scans, lowMz, highMz, resMz, ...)
 
- \S4method{chromatogram}{mzRpwiz}(object, chrom)
+ \S4method{chromatogram}{mzRpwiz}(object, chrom, drop = TRUE)
 
- \S4method{chromatograms}{mzRpwiz}(object, chrom)  ## same as chromatogram
+ \S4method{chromatograms}{mzRpwiz}(object, chrom, drop = TRUE)  ## same as chromatogram
 
  \S4method{chromatogramHeader}{mzRpwiz}(object, chrom)
 

--- a/src/RcppPwiz.cpp
+++ b/src/RcppPwiz.cpp
@@ -875,8 +875,8 @@ Rcpp::DataFrame RcppPwiz::getChromatogramsInfo( int whichChrom )
 	intensity.push_back(p.intensity);
       }
 
-      chromatogramsInfo = Rcpp::DataFrame::create(Rcpp::_["time"] = time,
-						  Rcpp::_[c->id]  = intensity);
+      chromatogramsInfo = Rcpp::DataFrame::create(Rcpp::_["rtime"] = time,
+						  Rcpp::_["intensity"] = intensity);
 
     }
     return(chromatogramsInfo);


### PR DESCRIPTION
This PR fixes the column names of the `data.frame`s returned by `chromatogram()` to `"rtime"` and `"intensity"` to be consistent with the data returned by the `peaks()` function (that returns columns named `"mz"` and `"intensity"`).

This PR fixes #304
