### PR TITLE
Fix build on Windows ARM64 (#319)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.45.1
+Version: 2.45.2
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Authors@R: c(
     person("Steffen", "Neumann", email="sneumann@ipb-halle.de", role=c("aut","cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mzR
 Type: Package
 Title: parser for netCDF, mzXML and mzML and mzIdentML files
        (mass spectrometry data)
-Version: 2.45.2
+Version: 2.45.3
 Author: Bernd Fischer, Steffen Neumann, Laurent Gatto, Qiang Kou, Johannes Rainer
 Authors@R: c(
     person("Steffen", "Neumann", email="sneumann@ipb-halle.de", role=c("aut","cre")),

--- a/src/boost_aux/libs/nowide/src/iostream.cpp
+++ b/src/boost_aux/libs/nowide/src/iostream.cpp
@@ -222,7 +222,7 @@ namespace detail {
     {
     }
 
-    winconsole_istream::winconsole_istream(winconsole_ostream* tieStream=0) : std::istream(0)
+    winconsole_istream::winconsole_istream(winconsole_ostream* tieStream) : std::istream(0)
     {
         HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
         d.reset(new console_input_buffer(h));

--- a/src/pwiz/utility/misc/Filesystem.cpp
+++ b/src/pwiz/utility/misc/Filesystem.cpp
@@ -138,7 +138,7 @@ extern "C"
         );
 
     PVOID GetLibraryProcAddress(PSTR LibraryName, PSTR ProcName) {
-        return GetProcAddress(GetModuleHandleA(LibraryName), ProcName);
+        return (PVOID)GetProcAddress(GetModuleHandleA(LibraryName), ProcName);
     }
 
     typedef struct __PUBLIC_OBJECT_TYPE_INFORMATION {


### PR DESCRIPTION
Fixes #319.

## Problem

The Windows ARM64 build fails while compiling the vendored ProteoWizard sources:

```
pwiz/utility/misc/Filesystem.cpp:141:16: error: cannot initialize return object of type 'PVOID' (aka 'void *') with an rvalue of type 'FARPROC' (aka 'long long (*)()')
  141 |         return GetProcAddress(GetModuleHandleA(LibraryName), ProcName);
```

(see the [r-universe build log](https://github.com/r-universe/bioc/actions/runs/30351752691/job/90253531042))

`GetProcAddress` returns a `FARPROC` (a function pointer). The clang toolchain used for Windows arm64 refuses the implicit conversion of that function pointer to `PVOID`. MSVC and the x86_64 clang builds accept it, which is why only the arm64 job breaks.

## Fix

Add an explicit `(PVOID)` cast in `GetLibraryProcAddress`, matching the C-style casts already applied to the results of this function everywhere else in the file. This is a no-op on the platforms that already build, and unblocks Windows arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)